### PR TITLE
Fixe specs

### DIFF
--- a/lib/gon.rb
+++ b/lib/gon.rb
@@ -17,6 +17,10 @@ module Gon
       @request_env[:gon]
     end
 
+    def all_variables=(values)
+      raise "You can't use Gon public methods for storing data"
+    end
+
     def clear
       @request_env[:gon] = {}
     end
@@ -37,7 +41,7 @@ module Gon
     end
 
     def request=(request_id)
-      @request_id = request_id      
+      @request_id = request_id
     end
 
     def method_missing(m, *args, &block)
@@ -61,10 +65,10 @@ module Gon
 
     def rabl(view_path, options = {})
       if !defined?(Gon::Rabl)
-        raise NoMethodError.new('You should define Rabl in your Gemfile') 
+        raise NoMethodError.new('You should define Rabl in your Gemfile')
       end
-      rabl_data = Gon::Rabl.parse_rabl(view_path, options[:controller] || 
-                                                  @request_env['action_controller.instance'] || 
+      rabl_data = Gon::Rabl.parse_rabl(view_path, options[:controller] ||
+                                                  @request_env['action_controller.instance'] ||
                                                   @request_env['action_controller.rescue.response'].
                                                     instance_variable_get('@template').
                                                     instance_variable_get('@controller'))
@@ -81,13 +85,13 @@ module Gon
 
     def jbuilder(view_path, options = {})
       if RUBY_VERSION !~ /9/
-        raise NoMethodError.new('You can use Jbuilder support only in 1.9+') 
+        raise NoMethodError.new('You can use Jbuilder support only in 1.9+')
       elsif !defined?(Gon::Jbuilder)
-        raise NoMethodError.new('You should define Jbuilder in your Gemfile') 
+        raise NoMethodError.new('You should define Jbuilder in your Gemfile')
       end
 
-      jbuilder_data = Gon::Jbuilder.parse_jbuilder(view_path, options[:controller] || 
-                                                  @request_env['action_controller.instance'] || 
+      jbuilder_data = Gon::Jbuilder.parse_jbuilder(view_path, options[:controller] ||
+                                                  @request_env['action_controller.instance'] ||
                                                   @request_env['action_controller.rescue.response'].
                                                     instance_variable_get('@template').
                                                     instance_variable_get('@controller'))

--- a/spec/gon/gon_spec.rb
+++ b/spec/gon/gon_spec.rb
@@ -1,7 +1,7 @@
 # gon_spec_rb
 require 'gon'
 
-describe Gon, '#all_variables' do 
+describe Gon, '#all_variables' do
 
   before(:each) do
     Gon.request_env = {}
@@ -41,13 +41,26 @@ describe Gon, '#all_variables' do
     lambda { Gon.all_variables = 123 }.should raise_error
   end
 
-  it 'render json from rabl template' do
-    Gon.clear
-    controller = ActionController::Base.new
-    objects = [1,2]
-    controller.instance_variable_set('@objects', objects)
-    Gon.rabl 'spec/test_data/sample.rabl', :controller => controller
-    Gon.objects.length.should == 2
+  context 'render json from rabl template' do
+    before :each do
+      Gon.clear
+      controller.instance_variable_set('@objects', objects)
+    end
+
+    let(:controller) { ActionController::Base.new}
+    let(:objects) { [1,2]}
+
+    it 'raises an error if rabl is not included' do
+      expect { Gon.rabl 'spec/test_data/sample.rabl', :controller => controller}.to raise_error
+    end
+
+    it 'works if rabl is included' do
+      require 'rabl'
+      require 'gon/rabl'
+      Gon.rabl 'spec/test_data/sample.rabl', :controller => controller
+      Gon.objects.length.should == 2
+    end
+
   end
 
   if RUBY_VERSION =~ /1.9/


### PR DESCRIPTION
Hi,
Just a little pull request to fix 2 failing specs.

The first one :

`Gon#all_variables render json from rabl template raises an error if rabl is not included
     Failure/Error: expect { Gon.rabl 'spec/test_data/sample.rabl', :controller => controller}.to raise_error
       expected Exception but nothing was raised`

Is probably due to the last pull request making  RABL an optional dependency.

The second one : 

Gon#all_variables returns exception if try to set public method as variable
     Failure/Error: lambda { Gon.all_variables = 123 }.should raise_error
       expected Exception but nothing was raised

As Gon.all_variable returned @request_env[:gon], Gon.all_variable = '123' was setting  @request_env[:gon] to '123' instead of raising an error.

Thanks for that great gem !
