### PR TITLE
Just a little code cleaning

### DIFF
--- a/lib/gon.rb
+++ b/lib/gon.rb
@@ -85,11 +85,6 @@ module Gon
         end
       end
     end
-    alias_method :orig_jbuilder, :jbuilder
-
-    def jbuilder(*options)
-      orig_jbuilder(*options)
-    end
 
     private
 


### PR DESCRIPTION
Hi, 
This few lines are useless since the last commit, as we don't have any more the special case where we need to raise an error when ruby version is inferior than 1.9.
