### PR TITLE
add option :need_script_tag

### DIFF
--- a/lib/gon/helpers.rb
+++ b/lib/gon/helpers.rb
@@ -11,7 +11,8 @@ module Gon
         if Gon.request_env && Gon.all_variables.present? && Gon.request == request.object_id
           data = Gon.all_variables
           namespace = options[:namespace] || 'gon'
-          start = ((options[:need_script_tag].nil? || options[:need_script_tag])  ? '<script>' : '') + 'window.' + namespace + ' = {};'
+          need_tag = options[:need_script_tag].nil? || options[:need_script_tag]
+          start = (need_tag  ? '<script>' : '') + 'window.' + namespace + ' = {};'
           script = ''
           if options[:camel_case]
             data.each do |key, val|
@@ -22,7 +23,7 @@ module Gon
               script << namespace + '.' + key.to_s + '=' + val.to_json + ';'
             end
           end
-          script = start + Gon::Escaper.escape(script) + ((options[:need_script_tag].nil? || options[:need_script_tag]) ? '</script>' : '')
+          script = start + Gon::Escaper.escape(script) + (need_tag ? '</script>' : '')
           script.html_safe
         else
           ""


### PR DESCRIPTION
Added option :need_script_tag, which controls the insertion of the tag <script>. useful in .js templates
