### PR TITLE
We should not break HTML entity, just escape 

### DIFF
--- a/lib/gon/escaper.rb
+++ b/lib/gon/escaper.rb
@@ -3,7 +3,7 @@ module Gon
     class << self
 
       GON_JS_ESCAPE_MAP = {
-        '</'    => '<\/'
+        '</'    => '\u003C/'
       }
 
       def escape(javascript)


### PR DESCRIPTION
make it compatible with https://github.com/rails/rails/blob/master/activesupport/lib/active_support/json/encoding.rb#L101
