### PR TITLE
Generate a proper JSON response in gon.watch

### DIFF
--- a/lib/gon/watch.rb
+++ b/lib/gon/watch.rb
@@ -109,7 +109,7 @@ class Gon
       def return_variable(value)
         controller = Gon::Base.get_controller
 
-        controller.render :text => value.to_json
+        controller.render :json => value
       end
 
     end

--- a/spec/gon/watch_spec.rb
+++ b/spec/gon/watch_spec.rb
@@ -54,7 +54,7 @@ describe Gon::Watch do
     controller.params = params
     Gon::Request.env['action_controller.instance'] = controller
 
-    controller.should_receive('render').with(:text => '1')
+    controller.should_receive('render').with(:json => 1)
 
     Gon.watch.a = 1
   end


### PR DESCRIPTION
`gon.watch`'s render response of the target variable was not being done as a JSON response, so `$.ajax` on the browser end couldn't parse the delivered string response. This commit uses `render :json` rather than `render :text` to send the data so that the data is parsed on the browser end, ready for use.
