### PR TITLE
Exceptions occur sometimes on assigning gon variables. 

### DIFF
--- a/lib/gon.rb
+++ b/lib/gon.rb
@@ -41,7 +41,7 @@ class Gon
     end
 
     def set_variable(name, value)
-      Request.gon[name] = value
+      Request.gon[name] = value if Request.gon
     end
 
     def all_variables


### PR DESCRIPTION
I think better not assign variable when somehow Request.gon is unavailable than generate an exception and show 500 to end user. We have experienced those bugs and they are quite annoying. I cannot reproduce that manually though.
