### PR TITLE
Added spec_helper and cleaned up specs. Now all specs require 'spec_help...

### DIFF
--- a/lib/gon.rb
+++ b/lib/gon.rb
@@ -6,12 +6,8 @@ require 'gon/watch'
 require 'gon/request'
 require 'gon/helpers'
 require 'gon/escaper'
-if defined?(Rabl)
-  require 'gon/rabl'
-end
-if defined?(Jbuilder)
-  require 'gon/jbuilder'
-end
+require 'gon/rabl'
+require 'gon/jbuilder'
 
 class Gon
   class << self
@@ -61,20 +57,13 @@ class Gon
     end
 
     def rabl(*args)
-      unless Gon.constants.include?(:Rabl)
-        raise "Possible wrong require order problem - try to add `gem 'rabl'` before `gem 'gon'` in your Gemfile"
-      end
       data, options = Gon::Rabl.handler(args)
-
       store_builder_data 'rabl', data, options
     end
 
     def jbuilder(*args)
-      unless Gon.constants.include?(:Jbuilder)
-        raise "Possible wrong require order problem - try to add `gem 'jbuilder'` before `gem 'gon'` in your Gemfile"
-      end
+      ensure_template_handler_is_defined
       data, options = Gon::Jbuilder.handler(args)
-
       store_builder_data 'jbuilder', data, options
     end
 
@@ -104,6 +93,13 @@ class Gon
           method.to_s[0..-2]
         end
       )
+    end
+    
+    # JbuilderTemplate will not be defined if jbuilder is required
+    # before gon. By loading jbuilder again, JbuilderTemplate will
+    # now be defined
+    def ensure_template_handler_is_defined
+      load 'jbuilder.rb' unless defined?(JbuilderTemplate)
     end
 
   end

--- a/lib/gon/global.rb
+++ b/lib/gon/global.rb
@@ -15,20 +15,13 @@ class Gon
       end
 
       def rabl(*args)
-        unless Gon.constants.include?(:Rabl)
-          raise "Possible wrong require order problem - try to add `gem 'rabl'` before `gem 'gon'` in your Gemfile"
-        end
         data, options = Gon::Rabl.handler(args, true)
-
         store_builder_data 'rabl', data, options
       end
 
       def jbuilder(*args)
-        unless Gon.constants.include?(:Jbuilder)
-          raise "Possible wrong require order problem - try to add `gem 'jbuilder'` before `gem 'gon'` in your Gemfile"
-        end
+        ensure_template_handler_is_defined
         data, options = Gon::Jbuilder.handler(args, true)
-
         store_builder_data 'jbuilder', data, options
       end
 

--- a/spec/gon/basic_spec.rb
+++ b/spec/gon/basic_spec.rb
@@ -1,4 +1,4 @@
-require 'gon'
+require 'spec_helper'
 
 describe Gon do
 

--- a/spec/gon/global_spec.rb
+++ b/spec/gon/global_spec.rb
@@ -1,4 +1,4 @@
-require 'gon'
+require 'spec_helper'
 
 describe Gon::Global do
 

--- a/spec/gon/jbuilder_spec.rb
+++ b/spec/gon/jbuilder_spec.rb
@@ -1,14 +1,10 @@
-# rabl_spec_rb
-require 'gon'
+require 'spec_helper'
 
 describe Gon do
 
   before(:each) do
     Gon::Request.env = {}
   end
-
-  require 'jbuilder'
-  require 'gon/jbuilder'
 
   describe '.jbuilder' do
     context 'render jbuilder templates' do

--- a/spec/gon/rabl_spec.rb
+++ b/spec/gon/rabl_spec.rb
@@ -1,5 +1,4 @@
-# rabl_spec_rb
-require 'gon'
+require 'spec_helper'
 
 describe Gon do
 
@@ -8,9 +7,6 @@ describe Gon do
   end
 
   describe '.rabl' do
-
-    require 'rabl'
-    require 'gon/rabl'
 
     before :each do
       Gon.clear

--- a/spec/gon/templates_spec.rb
+++ b/spec/gon/templates_spec.rb
@@ -1,16 +1,10 @@
-# rabl_spec_rb
-require 'gon'
+require 'spec_helper'
 
 describe Gon do
 
   before(:each) do
     Gon::Request.env = {}
   end
-
-  require 'jbuilder'
-  require 'gon/jbuilder'
-  require 'rabl'
-  require 'gon/rabl'
 
   describe '.get_template_path' do
     context 'template is specified' do

--- a/spec/gon/watch_spec.rb
+++ b/spec/gon/watch_spec.rb
@@ -1,4 +1,4 @@
-require 'gon'
+require 'spec_helper'
 
 describe Gon::Watch do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'gon'
+require 'jbuilder'
+require 'rabl'


### PR DESCRIPTION
Added spec_helper and cleaned up specs. Now all specs require 'spec_helper'. Specs previously did not pass when run individually. They now do. spec_helper only requires gon, rabl, and jbuilder to ensure requires are consistent with use of the gon gem. Also, removed the error raising inside rabl and jbuilder methods as the Gon::Rabl and Gon::Jbuilder modules are no longer conditionally required.
