### PR TITLE
Don't wipe out gon data upon AJAX request

### DIFF
--- a/lib/gon/base.rb
+++ b/lib/gon/base.rb
@@ -8,6 +8,7 @@ class Gon
           script = ""
         else
           script = "window.#{namespace} = {};"
+        end
 
         script << formatted_data(namespace, cameled, watch)
         script = Gon::Escaper.escape_unicode(script)


### PR DESCRIPTION
When I render a page with some gon data
And I send an AJAX request to another controller action (name it update_gon) for additional gon data
And I have `= include_gon` in the update_gon.html.haml, which is rendered without layout
The previous javascript gon variables should not be wiped out

Clearing of `window.gon` should occur only with first inclusion, or, as I propose, make it optional.
