### PR TITLE
Run transpec so that the specs uniformly use RSpec 3.0.x syntax.

### DIFF
--- a/spec/gon/basic_spec.rb
+++ b/spec/gon/basic_spec.rb
@@ -11,8 +11,8 @@ describe Gon do
       Gon.a = 1
       Gon.b = 2
       Gon.c = Gon.a + Gon.b
-      Gon.c.should == 3
-      Gon.all_variables.should == { 'a' => 1, 'b' => 2, 'c' => 3 }
+      expect(Gon.c).to eq(3)
+      expect(Gon.all_variables).to eq({ 'a' => 1, 'b' => 2, 'c' => 3 })
     end
 
     it 'supports all data types' do
@@ -35,7 +35,7 @@ describe Gon do
         check["variable#{i}"] = i
       end
 
-      Gon.all_variables.should == check
+      expect(Gon.all_variables).to eq(check)
     end
 
     it 'can set and get variable with dynamic name' do
@@ -43,14 +43,14 @@ describe Gon do
       var_name = "variable#{rand}"
 
       Gon.set_variable(var_name, 1)
-      Gon.get_variable(var_name).should == 1
+      expect(Gon.get_variable(var_name)).to eq(1)
     end
 
     it 'can be support new push syntax' do
       Gon.clear
 
       Gon.push({ :int => 1, :string => 'string' })
-      Gon.all_variables.should == { 'int' => 1, 'string' => 'string' }
+      expect(Gon.all_variables).to eq({ 'int' => 1, 'string' => 'string' })
     end
 
     it 'push with wrong object' do
@@ -68,130 +68,139 @@ describe Gon do
       Gon.clear
       Gon::Request.
         instance_variable_set(:@request_id, request.object_id)
-      ActionView::Base.
+      expect(ActionView::Base.
         instance_methods.
         map(&:to_s).
-        include?('include_gon').should == true
+        include?('include_gon')).to eq(true)
       @base = ActionView::Base.new
       @base.request = request
     end
 
     it 'outputs correct js with an integer' do
       Gon.int = 1
-      @base.include_gon.should == '<script type="text/javascript">' +
+      expect(@base.include_gon).to eq('<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
                                     'window.gon={};' +
                                     'gon.int=1;' +
                                     "\n//]]>\n" +
-                                  '</script>'
+                                  '</script>')
     end
 
     it 'outputs correct js with a string' do
       Gon.str = %q(a'b"c)
-      @base.include_gon.should == '<script type="text/javascript">' +
+      expect(@base.include_gon).to eq('<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
                                     'window.gon={};' +
                                     %q(gon.str="a'b\"c";) +
                                     "\n//]]>\n" +
-                                  '</script>'
+                                  '</script>')
     end
 
     it 'outputs correct js with a script string' do
       Gon.str = %q(</script><script>alert('!')</script>)
-      @base.include_gon.should == '<script type="text/javascript">' +
+      expect(@base.include_gon).to eq('<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
                                     'window.gon={};' +
                                     %q(gon.str="\u003C/script><script>alert('!')\u003C/script>";) +
                                     "\n//]]>\n" +
-                                  '</script>'
+                                  '</script>')
     end
 
     it 'outputs correct js with an integer, camel-case and namespace' do
       Gon.int_cased = 1
-      @base.include_gon(camel_case: true, namespace: 'camel_cased').should == \
+      expect(@base.include_gon(camel_case: true, namespace: 'camel_cased')).to eq( \
                                   '<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
                                     'window.camel_cased={};' +
                                     'camel_cased.intCased=1;' +
                                     "\n//]]>\n" +
                                   '</script>'
+      )
     end
 
     it 'outputs correct js with camel_depth = :recursive' do
       Gon.test_hash = { test_depth_one: { test_depth_two: 1 } }
-      @base.include_gon(camel_case: true, camel_depth: :recursive).should == \
+      expect(@base.include_gon(camel_case: true, camel_depth: :recursive)).to eq( \
                                   '<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
                                     'window.gon={};' +
                                     'gon.testHash={"testDepthOne":{"testDepthTwo":1}};' +
                                     "\n//]]>\n" +
                                   '</script>'
+      )
     end
 
     it 'outputs correct js with camel_depth = 2' do
       Gon.test_hash = { test_depth_one: { test_depth_two: 1 } }
-      @base.include_gon(camel_case: true, camel_depth: 2).should == \
+      expect(@base.include_gon(camel_case: true, camel_depth: 2)).to eq( \
                                   '<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
                                     'window.gon={};' +
                                     'gon.testHash={"testDepthOne":{"test_depth_two":1}};' +
                                     "\n//]]>\n" +
                                   '</script>'
+      )
     end
 
     it 'outputs correct js with an integer and without tag' do
       Gon.int = 1
-      @base.include_gon(need_tag: false).should == \
+      expect(@base.include_gon(need_tag: false)).to eq( \
                                   'window.gon={};' +
                                   'gon.int=1;'
+      )
     end
 
     it 'outputs correct js without variables, without tag and gon init if before there was data' do
       Gon::Request.
         instance_variable_set(:@request_id, 123)
       Gon::Request.instance_variable_set(:@request_env, { 'gon' => { :a => 1 } })
-      @base.include_gon(need_tag: false, init: true).should == \
+      expect(@base.include_gon(need_tag: false, init: true)).to eq( \
                                   'window.gon={};'
+      )
     end
 
     it 'outputs correct js without variables, without tag and gon init' do
-      @base.include_gon(need_tag: false, init: true).should == \
+      expect(@base.include_gon(need_tag: false, init: true)).to eq( \
                                   'window.gon={};'
+      )
     end
 
     it 'outputs correct js without variables, without tag, gon init and an integer' do
       Gon.int = 1
-      @base.include_gon(need_tag: false, init: true).should == \
+      expect(@base.include_gon(need_tag: false, init: true)).to eq( \
                                   'window.gon={};' +
                                   'gon.int=1;'
+      )
     end
 
     it 'outputs correct js without cdata, without type, gon init and an integer' do
       Gon.int = 1
-      @base.include_gon(cdata: false, type: false).should == \
+      expect(@base.include_gon(cdata: false, type: false)).to eq( \
                                   '<script>' +
                                     "\n" +
                                     'window.gon={};' +
                                     'gon.int=1;' +
                                     "\n" +
                                   '</script>'
+      )
     end
 
     it 'outputs correct js with type text/javascript' do
-      @base.include_gon(need_type: true, init: true).should == \
+      expect(@base.include_gon(need_type: true, init: true)).to eq( \
                                   '<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
                                     'window.gon={};'\
                                     "\n//]]>\n" +
                                   '</script>'
+      )
     end
 
   end
 
   it 'returns exception if try to set public method as variable' do
     Gon.clear
-    lambda { Gon.all_variables = 123 }.should raise_error
-    lambda { Gon.rabl = 123 }.should raise_error
+    expect { Gon.all_variables = 123 }.to raise_error
+    expect { Gon.rabl = 123 }.to raise_error
   end
 
   describe '#check_for_rabl_and_jbuilder' do
@@ -200,16 +209,16 @@ describe Gon do
 
     it 'should be able to handle ruby 1.8.7 style constants array (strings)' do
       constants_as_strings = Gon.constants.map(&:to_s)
-      Gon.stub(:constants) { constants_as_strings }
-      lambda { Gon.rabl 'spec/test_data/sample.rabl', :controller => controller }.should_not raise_error
-      lambda { Gon.jbuilder 'spec/test_data/sample.json.jbuilder', :controller => controller }.should_not raise_error
+      allow(Gon).to receive(:constants) { constants_as_strings }
+      expect { Gon.rabl 'spec/test_data/sample.rabl', :controller => controller }.not_to raise_error
+      expect { Gon.jbuilder 'spec/test_data/sample.json.jbuilder', :controller => controller }.not_to raise_error
     end
 
     it 'should be able to handle ruby 1.9+ style constants array (symbols)' do
       constants_as_symbols = Gon.constants.map(&:to_sym)
-      Gon.stub(:constants) { constants_as_symbols }
-      lambda { Gon.rabl 'spec/test_data/sample.rabl', :controller => controller }.should_not raise_error
-      lambda { Gon.jbuilder 'spec/test_data/sample.json.jbuilder', :controller => controller }.should_not raise_error
+      allow(Gon).to receive(:constants) { constants_as_symbols }
+      expect { Gon.rabl 'spec/test_data/sample.rabl', :controller => controller }.not_to raise_error
+      expect { Gon.jbuilder 'spec/test_data/sample.json.jbuilder', :controller => controller }.not_to raise_error
     end
   end
 

--- a/spec/gon/global_spec.rb
+++ b/spec/gon/global_spec.rb
@@ -13,8 +13,8 @@ describe Gon::Global do
       Gon.global.a = 1
       Gon.global.b = 2
       Gon.global.c = Gon.global.a + Gon.global.b
-      Gon.global.c.should == 3
-      Gon.global.all_variables.should == { 'a' => 1, 'b' => 2, 'c' => 3 }
+      expect(Gon.global.c).to eq(3)
+      expect(Gon.global.all_variables).to eq({ 'a' => 1, 'b' => 2, 'c' => 3 })
     end
 
     it 'supports all data types' do
@@ -35,72 +35,72 @@ describe Gon::Global do
     before(:each) do
       Gon.clear
       Gon.global.clear
-      ActionView::Base.
+      expect(ActionView::Base.
         instance_methods.
         map(&:to_s).
-        include?('include_gon').should == true
+        include?('include_gon')).to eq(true)
       @base = ActionView::Base.new
       @base.request = request
     end
 
     it 'outputs correct js with an integer' do
       Gon.global.int = 1
-      @base.include_gon.should == "<script type=\"text/javascript\">" +
+      expect(@base.include_gon).to eq("<script type=\"text/javascript\">" +
                                     "\n//<![CDATA[\n" +
                                     "window.gon={};" +
                                     "gon.global={\"int\":1};" +
                                     "\n//]]>\n" +
-                                  "</script>"
+                                  "</script>")
     end
 
     it 'outputs correct js with an integer and integer in Gon' do
       Gon.int = 1
       Gon.global.int = 1
-      @base.include_gon.should == "<script type=\"text/javascript\">" +
+      expect(@base.include_gon).to eq("<script type=\"text/javascript\">" +
                                     "\n//<![CDATA[\n" +
                                     "window.gon={};" +
                                     "gon.int=1;" +
                                     "gon.global={\"int\":1};" +
                                     "\n//]]>\n" +
-                                  "</script>"
+                                  "</script>")
     end
 
     it 'outputs correct js with a string' do
       Gon.global.str = %q(a'b"c)
-      @base.include_gon.should == "<script type=\"text/javascript\">" +
+      expect(@base.include_gon).to eq("<script type=\"text/javascript\">" +
                                     "\n//<![CDATA[\n" +
                                     "window.gon={};" +
                                     "gon.global={\"str\":\"a'b\\\"c\"};" +
                                     "\n//]]>\n" +
-                                  "</script>"
+                                  "</script>")
     end
 
     it 'outputs correct js with a script string' do
       Gon.global.str = %q(</script><script>alert('!')</script>)
-      @base.include_gon.should == "<script type=\"text/javascript\">" +
+      expect(@base.include_gon).to eq("<script type=\"text/javascript\">" +
                                     "\n//<![CDATA[\n" +
                                     "window.gon={};" +
                                     "gon.global={\"str\":\"\\u003C/script><script>alert('!')\\u003C/script>\"};" +
                                     "\n//]]>\n" +
-                                  "</script>"
+                                  "</script>")
     end
 
     it 'outputs correct js with a unicode line separator' do
       Gon.global.str = "\u2028"
-      @base.include_gon.should == "<script type=\"text/javascript\">" +
+      expect(@base.include_gon).to eq("<script type=\"text/javascript\">" +
                                     "\n//<![CDATA[\n" +
                                     "window.gon={};" +
                                     "gon.global={\"str\":\"&#x2028;\"};" +
                                     "\n//]]>\n" +
-                                  "</script>"
+                                  "</script>")
     end
 
   end
 
   it 'returns exception if try to set public method as variable' do
     Gon.global.clear
-    lambda { Gon.global.all_variables = 123 }.should raise_error
-    lambda { Gon.global.rabl = 123 }.should raise_error
+    expect { Gon.global.all_variables = 123 }.to raise_error
+    expect { Gon.global.rabl = 123 }.to raise_error
   end
 
   context 'with jbuilder and rabl' do
@@ -115,17 +115,17 @@ describe Gon::Global do
 
     it 'works fine with rabl' do
       Gon.global.rabl :template => 'spec/test_data/sample.rabl', :controller => controller
-      Gon.global.objects.length.should == 2
+      expect(Gon.global.objects.length).to eq(2)
     end
 
     it 'works fine with jbuilder' do
       Gon.global.jbuilder :template => 'spec/test_data/sample.json.jbuilder', :controller => controller
-      Gon.global.objects.length.should == 2
+      expect(Gon.global.objects.length).to eq(2)
     end
 
     it 'should throw exception, if use rabl or jbuilder without :template' do
-      lambda { Gon.global.rabl }.should raise_error
-      lambda { Gon.global.jbuilder }.should raise_error
+      expect { Gon.global.rabl }.to raise_error
+      expect { Gon.global.jbuilder }.to raise_error
     end
 
   end

--- a/spec/gon/jbuilder_spec.rb
+++ b/spec/gon/jbuilder_spec.rb
@@ -15,20 +15,20 @@ describe Gon do
 
       it 'render json from jbuilder template' do
         Gon.jbuilder 'spec/test_data/sample.json.jbuilder', :controller => controller
-        Gon.objects.length.should == 2
+        expect(Gon.objects.length).to eq(2)
       end
 
       it 'render json from jbuilder template with locals' do
         Gon.jbuilder 'spec/test_data/sample_with_locals.json.jbuilder',
                      :controller => controller,
                      :locals => { :some_local => 1234, :some_complex_local => OpenStruct.new(:id => 1234) }
-        Gon.some_local.should == 1234
-        Gon.some_complex_local_id.should == 1234
+        expect(Gon.some_local).to eq(1234)
+        expect(Gon.some_complex_local_id).to eq(1234)
       end
 
       it 'render json from jbuilder template with locals' do
         Gon.jbuilder 'spec/test_data/sample_with_helpers.json.jbuilder', :controller => controller
-        Gon.date.should == 'about 6 hours'
+        expect(Gon.date).to eq('about 6 hours')
       end
 
       it 'render json from jbuilder template with controller methods' do
@@ -41,13 +41,13 @@ describe Gon do
         }
 
         Gon.jbuilder 'spec/test_data/sample_with_controller_method.json.jbuilder', :controller => controller
-        Gon.date.should == 'about 6 hours'
+        expect(Gon.date).to eq('about 6 hours')
       end
 
       it 'render json from jbuilder template with a partial' do
         controller.view_paths << 'spec/test_data'
         Gon.jbuilder 'spec/test_data/sample_with_partial.json.jbuilder', :controller => controller
-        Gon.objects.length.should == 2
+        expect(Gon.objects.length).to eq(2)
       end
 
     end

--- a/spec/gon/rabl_with_rabl_rails_spec.rb
+++ b/spec/gon/rabl_with_rabl_rails_spec.rb
@@ -20,7 +20,7 @@ describe Gon do
     context 'render template with deprecation' do
       it 'still works' do
         Gon.rabl 'spec/test_data/sample_rabl_rails.rabl', :controller => controller
-        Gon.objects.length.should == 2
+        expect(Gon.objects.length).to eq(2)
       end
     end
 
@@ -30,7 +30,7 @@ describe Gon do
           :template =>'spec/test_data/sample_rabl_rails.rabl',
           :controller => controller
         )
-        Gon.objects.map { |it| it['inspect'] }.should == %w(1 2)
+        expect(Gon.objects.map { |it| it['inspect'] }).to eq(%w(1 2))
       end
       
       it 'works with different locals object' do
@@ -39,18 +39,18 @@ describe Gon do
           :controller => controller,
           :locals => { :objects => [3, 4] }
         )
-        Gon.objects.map { |it| it['inspect'] }.should == %w(3 4)
+        expect(Gon.objects.map { |it| it['inspect'] }).to eq(%w(3 4))
       end
     end
 
     it 'works if rabl-rails is included' do
       Gon.rabl :template => 'spec/test_data/sample_rabl_rails.rabl', :controller => controller
-      Gon.objects.length.should == 2
+      expect(Gon.objects.length).to eq(2)
     end
 
     it 'works with ActionView::Helpers' do
       Gon.rabl :template =>'spec/test_data/sample_with_helpers_rabl_rails.rabl', :controller => controller
-      Gon.objects.first['time_ago'].should == 'about 6 hours'
+      expect(Gon.objects.first['time_ago']).to eq('about 6 hours')
     end
 
     it 'raise exception if rabl or rabl-rails is not included' do

--- a/spec/gon/rabl_with_rabl_spec.rb
+++ b/spec/gon/rabl_with_rabl_spec.rb
@@ -19,7 +19,7 @@ describe Gon do
     context 'render template with deprecation' do
       it 'still works' do
         Gon.rabl 'spec/test_data/sample.rabl', :controller => controller
-        Gon.objects.length.should == 2
+        expect(Gon.objects.length).to eq(2)
       end
     end
 
@@ -29,7 +29,7 @@ describe Gon do
           :template   => 'spec/test_data/sample.rabl',
           :controller => controller
         )
-        Gon.objects.map { |it| it['object']['inspect'] }.should == %w(1 2)
+        expect(Gon.objects.map { |it| it['object']['inspect'] }).to eq(%w(1 2))
       end
 
       it 'works with different locals object' do
@@ -38,18 +38,18 @@ describe Gon do
           :controller => controller,
           :locals     => { :objects => [3, 4] }
         )
-        Gon.objects.map { |it| it['object']['inspect'] }.should == %w(3 4)
+        expect(Gon.objects.map { |it| it['object']['inspect'] }).to eq(%w(3 4))
       end
     end
 
     it 'works if rabl is included' do
       Gon.rabl :template => 'spec/test_data/sample.rabl', :controller => controller
-      Gon.objects.length.should == 2
+      expect(Gon.objects.length).to eq(2)
     end
 
     it 'works with ActionView::Helpers' do
       Gon.rabl :template => 'spec/test_data/sample_with_helpers.rabl', :controller => controller
-      Gon.objects.first['object']['time_ago'].should == 'about 6 hours'
+      expect(Gon.objects.first['object']['time_ago']).to eq('about 6 hours')
     end
 
     it 'raise exception if rabl is not included' do
@@ -63,11 +63,11 @@ describe Gon do
       context 'template is specified' do
 
         it 'add the extension if not included in the template name' do
-          Gon::Base.send(:get_template_path, { :template => 'spec/test_data/sample' }, 'rabl').should eql('spec/test_data/sample.rabl')
+          expect(Gon::Base.send(:get_template_path, { :template => 'spec/test_data/sample' }, 'rabl')).to eql('spec/test_data/sample.rabl')
         end
 
         it 'return the specified template' do
-          Gon::Base.send(:get_template_path, { :template => 'spec/test_data/sample.rabl' }, 'rabl').should eql('spec/test_data/sample.rabl')
+          expect(Gon::Base.send(:get_template_path, { :template => 'spec/test_data/sample.rabl' }, 'rabl')).to eql('spec/test_data/sample.rabl')
         end
 
       end
@@ -85,7 +85,7 @@ describe Gon do
 
         context 'the action doesn as a template at a different format' do
           it 'return the same template as the action with rabl extension' do
-            Gon::Base.send(:get_template_path, { :controller => controller }, 'rabl').should eql('app/views/action_controller/base/show.json.rabl')
+            expect(Gon::Base.send(:get_template_path, { :controller => controller }, 'rabl')).to eql('app/views/action_controller/base/show.json.rabl')
           end
         end
 

--- a/spec/gon/templates_spec.rb
+++ b/spec/gon/templates_spec.rb
@@ -6,11 +6,11 @@ describe Gon do
     context 'template is specified' do
 
       it 'add the extension if not included in the template name' do
-        Gon::Base.send(:get_template_path, { :template => 'spec/test_data/sample' }, 'jbuilder').should eql('spec/test_data/sample.jbuilder')
+        expect(Gon::Base.send(:get_template_path, { :template => 'spec/test_data/sample' }, 'jbuilder')).to eql('spec/test_data/sample.jbuilder')
       end
 
       it 'return the specified template' do
-        Gon::Base.send(:get_template_path, { :template => 'spec/test_data/sample.jbuilder' }, 'jbuilder').should eql('spec/test_data/sample.jbuilder')
+        expect(Gon::Base.send(:get_template_path, { :template => 'spec/test_data/sample.jbuilder' }, 'jbuilder')).to eql('spec/test_data/sample.jbuilder')
       end
 
     end
@@ -28,7 +28,7 @@ describe Gon do
 
       context 'the action doesn as a template at a different format' do
         it 'return the same template as the action with rabl extension' do
-          Gon::Base.send(:get_template_path, { :controller => controller }, 'jbuilder').should eql('app/views/action_controller/base/show.json.jbuilder')
+          expect(Gon::Base.send(:get_template_path, { :controller => controller }, 'jbuilder')).to eql('app/views/action_controller/base/show.json.jbuilder')
         end
       end
 

--- a/spec/gon/watch_spec.rb
+++ b/spec/gon/watch_spec.rb
@@ -21,14 +21,14 @@ describe Gon::Watch do
   it 'should add variables to Gon#all_variables hash' do
     Gon.a = 1
     Gon.watch.b = 2
-    Gon.all_variables.should == { 'a' => 1, 'b' => 2 }
+    expect(Gon.all_variables).to eq({ 'a' => 1, 'b' => 2 })
   end
 
   describe '#all_variables' do
 
     it 'should generate array with current request url, method type and variable names' do
       Gon.watch.a = 1
-      Gon.watch.all_variables.should == { 'a' => { 'url' => '/foo', 'method' => 'GET', 'name' => 'a' } }
+      expect(Gon.watch.all_variables).to eq({ 'a' => { 'url' => '/foo', 'method' => 'GET', 'name' => 'a' } })
     end
 
   end
@@ -37,8 +37,8 @@ describe Gon::Watch do
 
     it 'should render function with variables in gon namespace' do
       Gon.watch.a = 1
-      Gon.watch.render.should =~ /gon\.watch\s=/
-      Gon.watch.render.should =~ /gon\.watchedVariables/
+      expect(Gon.watch.render).to match(/gon\.watch\s=/)
+      expect(Gon.watch.render).to match(/gon\.watchedVariables/)
     end
 
   end
@@ -54,7 +54,7 @@ describe Gon::Watch do
     controller.params = params
     Gon.send(:current_gon).env['action_controller.instance'] = controller
 
-    controller.should_receive('render').with(:json => 1)
+    expect(controller).to receive('render').with(:json => 1)
 
     Gon.watch.a = 1
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,6 @@ end
 RSpec.configure do |config|
   config.before(:each) do
     @request = Thread.current['gon'] = Gon::Request.new({})
-    Gon.stub(:current_gon).and_return(@request)
+    allow(Gon).to receive(:current_gon).and_return(@request)
   end
 end


### PR DESCRIPTION
With this PR the specs uniformly use RSpec 3.0.x compliant syntax.
