### PR TITLE
Declare undisclosed dependency on Rails 3.2.x

### DIFF
--- a/gon.gemspec
+++ b/gon.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
-  s.add_dependency 'actionpack', '>= 2.3.0'
+  s.add_dependency 'actionpack', '>= 3.2.0'
   s.add_dependency 'json'
   s.add_development_dependency 'rabl'
   s.add_development_dependency 'rabl-rails'


### PR DESCRIPTION
Gon depends on ActionDispatch::Request#uuid which was introduced in Rails 3.2.0: https://github.com/rails/rails/commit/afde6fdd5ef3e6b0693a7e330777e85ef4cffddb

It would be nice to warn people using Rails 3.1 that it's incompatible since 
ActionPack in 3.1 doesn't provide `request.uuid`. :-)
