### PR TITLE
Feature: Improve performance by about 10x by adding dependency of Oj

### DIFF
--- a/gon.gemspec
+++ b/gon.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionpack', '>= 2.3.0'
   s.add_dependency 'request_store', '>= 1.0.5'
   s.add_dependency 'json'
+  s.add_dependency 'oj'
   s.add_development_dependency 'rabl'
   s.add_development_dependency 'rabl-rails'
   s.add_development_dependency 'rspec'

--- a/lib/gon.rb
+++ b/lib/gon.rb
@@ -9,6 +9,7 @@ require 'gon/helpers'
 require 'gon/escaper'
 require 'gon/rabl'
 require 'gon/jbuilder'
+require 'oj'
 
 class Gon
   class << self

--- a/lib/gon/base.rb
+++ b/lib/gon/base.rb
@@ -74,7 +74,7 @@ class Gon
 
       def to_json(value, camel_depth)
         # starts at two because 1 is the root key which is converted in the formatted_data method
-        convert_hash_keys(value, 2, camel_depth).to_json
+        Oj.dump(convert_hash_keys(value, 2, camel_depth), {mode: :compat, time_format: :ruby})
       end
 
       def convert_hash_keys(value, current_depth, max_depth)


### PR DESCRIPTION
I noticed that a call to include_gon was costing in the range of 100ms+ for me, so I got curious.

It turns out, most of the performance penalty is caused by using the default ruby implementation of JSON serialization. In my own work, I've made us of the Oj library to improve performance, so I gave that a try. That call that used to take 100ms+, now takes <10ms.

I ran the spec before and after, and curiously 1 of the 2 previously failing specs "Gon#include_gon outputs correct js with a script string" is now passing...

I know it's an extra dependency, but it seems worth it in cases where there is nothing in standard ruby that can deliver the same performance improvement.
