### PR TITLE
Fix bug when using caching with 'rabl' gem.

### DIFF
--- a/lib/gon/rabl.rb
+++ b/lib/gon/rabl.rb
@@ -43,7 +43,7 @@ class Gon
         locals ||= {}
         source = File.read(rabl_path)
         include_helpers
-        rabl_engine = ::Rabl::Engine.new(source, :format => 'json')
+        rabl_engine = ::Rabl::Engine.new(source, :format => 'json', :template => rabl_path)
         output = rabl_engine.render(controller, locals)
         JSON.parse(output)
       end


### PR DESCRIPTION
The `template` option is used when initializing the
`Rabl::Engine` and used in `cache_key_with_digest` later on.
If not given on instantiation, the exception below is raised
from `cache_key_with_digest` when instantiating the `Digestor`.

```
undefined method `gsub' for nil:NilClass
```
