### PR TITLE
If the window.gon variable is already defined, use it instead of overwriting it.

### DIFF
--- a/lib/gon/base.rb
+++ b/lib/gon/base.rb
@@ -5,8 +5,8 @@ class Gon
     class << self
 
       def render_data(options)
-        namespace, tag, cameled, camel_depth, watch, type, cdata, global_root = parse_options(options)
-        script = "window.#{namespace}=window.#{namespace}||{};"
+        namespace, tag, cameled, camel_depth, watch, type, cdata, global_root, namespace_check = parse_options(options)
+        script = namespace_check ? "window.#{namespace}=window.#{namespace}||{};" : "window.#{namespace}={};"
 
         script << formatted_data(namespace, cameled, camel_depth, watch, global_root)
         script = Gon::Escaper.escape_unicode(script)
@@ -56,8 +56,9 @@ class Gon
         type        = options[:type].nil? || options[:type]
         cdata       = options[:cdata].nil? || options[:cdata]
         global_root = options.has_key?(:global_root) ? options[:global_root] : 'global'
+        namespace_check = options.has_key?(:namespace_check) ? options[:namespace_check] : false
 
-        [namespace, tag, cameled, camel_depth, watch, type, cdata, global_root]
+        [namespace, tag, cameled, camel_depth, watch, type, cdata, global_root, namespace_check]
       end
 
       def formatted_data(namespace, keys_cameled, camel_depth, watch, global_root)

--- a/spec/gon/basic_spec.rb
+++ b/spec/gon/basic_spec.rb
@@ -80,7 +80,7 @@ describe Gon do
       Gon.int = 1
       expect(@base.include_gon).to eq('<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
-                                    'window.gon=window.gon||{};' +
+                                    'window.gon={};' +
                                     'gon.int=1;' +
                                     "\n//]]>\n" +
                                   '</script>')
@@ -90,7 +90,7 @@ describe Gon do
       Gon.str = %q(a'b"c)
       expect(@base.include_gon).to eq('<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
-                                    'window.gon=window.gon||{};' +
+                                    'window.gon={};' +
                                     %q(gon.str="a'b\"c";) +
                                     "\n//]]>\n" +
                                   '</script>')
@@ -101,7 +101,7 @@ describe Gon do
       escaped_str = "\\u003c/script\\u003e\\u003cscript\\u003ealert('!')\\u003c/script\\u003e"
       expect(@base.include_gon).to eq('<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
-                                    'window.gon=window.gon||{};' +
+                                    'window.gon={};' +
                                     %Q(gon.str="#{escaped_str}";) +
                                     "\n//]]>\n" +
                                   '</script>')
@@ -112,7 +112,7 @@ describe Gon do
       expect(@base.include_gon(camel_case: true, namespace: 'camel_cased')).to eq( \
                                   '<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
-                                    'window.camel_cased=window.camel_cased||{};' +
+                                    'window.camel_cased={};' +
                                     'camel_cased.intCased=1;' +
                                     "\n//]]>\n" +
                                   '</script>'
@@ -124,7 +124,7 @@ describe Gon do
       expect(@base.include_gon(camel_case: true, camel_depth: :recursive)).to eq( \
                                   '<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
-                                    'window.gon=window.gon||{};' +
+                                    'window.gon={};' +
                                     'gon.testHash={"testDepthOne":{"testDepthTwo":1}};' +
                                     "\n//]]>\n" +
                                   '</script>'
@@ -136,7 +136,7 @@ describe Gon do
       expect(@base.include_gon(camel_case: true, camel_depth: 2)).to eq( \
                                   '<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
-                                    'window.gon=window.gon||{};' +
+                                    'window.gon={};' +
                                     'gon.testHash={"testDepthOne":{"test_depth_two":1}};' +
                                     "\n//]]>\n" +
                                   '</script>'
@@ -148,7 +148,7 @@ describe Gon do
       expect(@base.include_gon(camel_case: true, camel_depth: :recursive)).to eq( \
                                   '<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
-                                    'window.gon=window.gon||{};' +
+                                    'window.gon={};' +
                                     'gon.testHash={"testDepthOne":[{"testDepthTwo":1},{"testDepthTwo":2}]};' +
                                     "\n//]]>\n" +
                                   '</script>'
@@ -158,7 +158,7 @@ describe Gon do
     it 'outputs correct js with an integer and without tag' do
       Gon.int = 1
       expect(@base.include_gon(need_tag: false)).to eq( \
-                                  'window.gon=window.gon||{};' +
+                                  'window.gon={};' +
                                   'gon.int=1;'
       )
     end
@@ -168,20 +168,20 @@ describe Gon do
         instance_variable_set(:@request_id, 123)
       Gon::Request.instance_variable_set(:@request_env, { 'gon' => { :a => 1 } })
       expect(@base.include_gon(need_tag: false, init: true)).to eq( \
-                                  'window.gon=window.gon||{};'
+                                  'window.gon={};'
       )
     end
 
     it 'outputs correct js without variables, without tag and gon init' do
       expect(@base.include_gon(need_tag: false, init: true)).to eq( \
-                                  'window.gon=window.gon||{};'
+                                  'window.gon={};'
       )
     end
 
     it 'outputs correct js without variables, without tag, gon init and an integer' do
       Gon.int = 1
       expect(@base.include_gon(need_tag: false, init: true)).to eq( \
-                                  'window.gon=window.gon||{};' +
+                                  'window.gon={};' +
                                   'gon.int=1;'
       )
     end
@@ -191,7 +191,7 @@ describe Gon do
       expect(@base.include_gon(cdata: false, type: false)).to eq( \
                                   '<script>' +
                                     "\n" +
-                                    'window.gon=window.gon||{};' +
+                                    'window.gon={};' +
                                     'gon.int=1;' +
                                     "\n" +
                                   '</script>'
@@ -202,17 +202,27 @@ describe Gon do
       expect(@base.include_gon(need_type: true, init: true)).to eq( \
                                   '<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
+                                    'window.gon={};'\
+                                    "\n//]]>\n" +
+                                  '</script>'
+      )
+    end
+
+    it 'outputs correct js with namespace check' do
+      expect(@base.include_gon(namespace_check: true)).to eq( \
+                                  '<script type="text/javascript">' +
+                                    "\n//<![CDATA[\n" +
                                     'window.gon=window.gon||{};'\
                                     "\n//]]>\n" +
                                   '</script>'
       )
     end
 
-    it 'outputs correct js which uses the existing variable if it is defined' do
-      expect(@base.include_gon(need_type: true, init: true)).to eq( \
+    it 'outputs correct js without namespace check' do
+      expect(@base.include_gon(namespace_check: false)).to eq( \
                                   '<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
-                                    'window.gon=window.gon||{};'\
+                                    'window.gon={};'\
                                     "\n//]]>\n" +
                                   '</script>'
       )
@@ -237,7 +247,7 @@ describe Gon do
         expect(@base.include_gon(init: true)).to eq( \
                                     '<script type="text/javascript">' +
                                       "\n//<![CDATA[\n" +
-                                      'window.gon=window.gon||{};'\
+                                      'window.gon={};'\
                                       "\n//]]>\n" +
                                     '</script>'
         )

--- a/spec/gon/global_spec.rb
+++ b/spec/gon/global_spec.rb
@@ -47,7 +47,7 @@ describe Gon::Global do
       Gon.global.int = 1
       expect(@base.include_gon).to eq("<script type=\"text/javascript\">" +
                                     "\n//<![CDATA[\n" +
-                                    "window.gon=window.gon||{};" +
+                                    "window.gon={};" +
                                     "gon.global={\"int\":1};" +
                                     "\n//]]>\n" +
                                   "</script>")
@@ -58,7 +58,7 @@ describe Gon::Global do
       Gon.global.int = 1
       expect(@base.include_gon).to eq("<script type=\"text/javascript\">" +
                                     "\n//<![CDATA[\n" +
-                                    "window.gon=window.gon||{};" +
+                                    "window.gon={};" +
                                     "gon.global={\"int\":1};" +
                                     "gon.int=1;" +
                                     "\n//]]>\n" +
@@ -69,7 +69,7 @@ describe Gon::Global do
       Gon.global.str = %q(a'b"c)
       expect(@base.include_gon).to eq("<script type=\"text/javascript\">" +
                                     "\n//<![CDATA[\n" +
-                                    "window.gon=window.gon||{};" +
+                                    "window.gon={};" +
                                     "gon.global={\"str\":\"a'b\\\"c\"};" +
                                     "\n//]]>\n" +
                                   "</script>")
@@ -80,7 +80,7 @@ describe Gon::Global do
       escaped_str = "\\u003c/script\\u003e\\u003cscript\\u003ealert('!')\\u003c/script\\u003e"
       expect(@base.include_gon).to eq("<script type=\"text/javascript\">" +
                                     "\n//<![CDATA[\n" +
-                                    "window.gon=window.gon||{};" +
+                                    "window.gon={};" +
                                     "gon.global={\"str\":\"#{escaped_str}\"};" +
                                     "\n//]]>\n" +
                                   "</script>")
@@ -90,7 +90,7 @@ describe Gon::Global do
       Gon.global.str = "\u2028"
       expect(@base.include_gon).to eq("<script type=\"text/javascript\">" +
                                     "\n//<![CDATA[\n" +
-                                    "window.gon=window.gon||{};" +
+                                    "window.gon={};" +
                                     "gon.global={\"str\":\"&#x2028;\"};" +
                                     "\n//]]>\n" +
                                   "</script>")
@@ -101,7 +101,7 @@ describe Gon::Global do
       Gon.global.str = 'global value'
       expect(@base.include_gon(global_root: '')).to eq("<script type=\"text/javascript\">" +
                                      "\n//<![CDATA[\n" +
-                                     "window.gon=window.gon||{};" +
+                                     "window.gon={};" +
                                      "gon.str=\"local value\";" +
                                      "\n//]]>\n" +
                                      "</script>")


### PR DESCRIPTION
Use case: I'm using a custom namespace `window.TOUT`.  But I may or may not already have `window.TOUT` initialized already.  This pull request gives the same default value, but doesn't overwrite it if it's already set.

If you think this feature is useful, then there are two questions:
1) Is this feature always present or is it configurable?
2) If it's configurable, is it on or off by default.

I can see a case where this change _could_ be a breaking change, but that would be a fairly poor implementation where they set a global variable use it, then allow it to be reset by gon and then use that.

I can really go either way on questions 1 or 2, so I thought I'd just ship the easiest option first, get your thoughts on it, and then improve based on your feedback.

Thanks,
Tom
