### PR TITLE
Only inject gon into ActionController::Base-like object in spec_helper

### DIFF
--- a/lib/gon/spec_helpers.rb
+++ b/lib/gon/spec_helpers.rb
@@ -7,8 +7,11 @@ class Gon
         module GonSession
           def process(*)
             # preload threadlocal & store controller instance
-            controller.gon
-            Gon.send(:current_gon).env[Gon::Base::ENV_CONTROLLER_KEY] = controller
+            if controller.is_a? ActionController::Base
+              controller.gon
+              Gon.send(:current_gon).env[Gon::Base::ENV_CONTROLLER_KEY] =
+               controller
+            end
             super
           end
         end


### PR DESCRIPTION
This is related to #141. The previous implementation would execute on any controller, but gon only injects itself into `ActionController::Base`. This is particularly damaging if you have a mixed environment that has other base ActionControllers (i.e. you have an api that bases from `rails-api`) since it tries to execute methods that weren't injected onto it.

I've simply added a check to ensure that objects are of type ActionController::Base before proceeding to setup gon for rspec.
