### PR TITLE
Fix forward slash scaping on tests for oj

### DIFF
--- a/spec/gon/basic_spec.rb
+++ b/spec/gon/basic_spec.rb
@@ -98,7 +98,11 @@ describe Gon do
 
     it 'outputs correct js with a script string' do
       Gon.str = %q(</script><script>alert('!')</script>)
-      escaped_str = "\\u003c/script\\u003e\\u003cscript\\u003ealert('!')\\u003c/script\\u003e"
+      if MultiJson.current_adapter.instance.class.name == 'MultiJson::Adapters::Oj'
+        escaped_str = "\\u003c\\/script\\u003e\\u003cscript\\u003ealert('!')\\u003c\\/script\\u003e"
+      else
+        escaped_str = "\\u003c/script\\u003e\\u003cscript\\u003ealert('!')\\u003c/script\\u003e"
+      end
       expect(@base.include_gon).to eq('<script type="text/javascript">' +
                                     "\n//<![CDATA[\n" +
                                     'window.gon={};' +

--- a/spec/gon/global_spec.rb
+++ b/spec/gon/global_spec.rb
@@ -77,7 +77,11 @@ describe Gon::Global do
 
     it 'outputs correct js with a script string' do
       Gon.global.str = %q(</script><script>alert('!')</script>)
-      escaped_str = "\\u003c/script\\u003e\\u003cscript\\u003ealert('!')\\u003c/script\\u003e"
+      if MultiJson.current_adapter.instance.class.name == 'MultiJson::Adapters::Oj'
+        escaped_str = "\\u003c\\/script\\u003e\\u003cscript\\u003ealert('!')\\u003c\\/script\\u003e"
+      else
+        escaped_str = "\\u003c/script\\u003e\\u003cscript\\u003ealert('!')\\u003c/script\\u003e"
+      end
       expect(@base.include_gon).to eq("<script type=\"text/javascript\">" +
                                     "\n//<![CDATA[\n" +
                                     "window.gon={};" +

--- a/spec/gon/watch_spec.rb
+++ b/spec/gon/watch_spec.rb
@@ -66,7 +66,11 @@ describe Gon::Watch do
     end
 
     context 'when request variable is json unsafe content' do
-      let(:expected) { %Q{"\\u003cscript\\u003e'\\"\\u003c/script\\u003e&#x2028;Dangerous"} }
+      if MultiJson.current_adapter.instance.class.name == 'MultiJson::Adapters::Oj'
+        let(:expected) { %Q{"\\u003cscript\\u003e'\\"\\u003c\\/script\\u003e&#x2028;Dangerous"} }
+      else
+        let(:expected) { %Q{"\\u003cscript\\u003e'\\"\\u003c/script\\u003e&#x2028;Dangerous"} }
+      end
 
       before do
         controller.stub(params: {


### PR DESCRIPTION
Oj seems to scape the forward slash, that is legal, but not required.
