### PR TITLE
Add deep merge mode

### DIFF
--- a/lib/gon.rb
+++ b/lib/gon.rb
@@ -54,11 +54,25 @@ class Gon
       current_gon.gon[name] = value
     end
 
-    def push(data = {})
+    def merge_variable(name, value)
+      old_value = all_variables[name]
+      if value.is_a?(Hash) && old_value.is_a?(Hash)
+        value = old_value.deep_merge(value)
+      end
+      set_variable(name, value)
+    end
+
+    def push(data = {}, merge = false)
       raise 'Object must have each_pair method' unless data.respond_to? :each_pair
 
-      data.each_pair do |name, value|
-        set_variable(name.to_s, value)
+      if merge
+        data.each_pair do |name, value|
+          merge_variable(name.to_s, value)
+        end
+      else
+        data.each_pair do |name, value|
+          set_variable(name.to_s, value)
+        end
       end
     end
 


### PR DESCRIPTION
Hi. Thanks for your library, it does the job well. I wanna to add a new feature called "merge mode". Currently if you try to add key to gon, that already exist there it just overrides old value. But with this feature if old value and new value are a hash it will use deep merge to set value. It might be useful in situation when you set complex object in abstract controller, controller callback & action.

To enable it add tiny initializer

``` ruby
#config/initializers/gon.rb
Gon.merge_mode!
```
