### PR TITLE
Added unwatchAll function to watch.js

### DIFF
--- a/coffee/watch.coffee
+++ b/coffee/watch.coffee
@@ -37,3 +37,9 @@ gon.unwatch = (name, fn) ->
     clearInterval(timer.timer)
     gon._timers[name].splice(index, 1)
     return
+
+gon.unwatchAll = ->
+  for variable, timers of gon._timers
+    for timer in timers
+      clearInterval(timer.timer)
+  gon._timers = {}

--- a/js/watch.js
+++ b/js/watch.js
@@ -62,3 +62,16 @@ gon.unwatch = function(name, fn) {
     return;
   }
 };
+
+gon.unwatchAll = function() {
+  var timer, timers, variable, _i, _len, _ref;
+  _ref = gon._timers;
+  for (variable in _ref) {
+    timers = _ref[variable];
+    for (_i = 0, _len = timers.length; _i < _len; _i++) {
+      timer = timers[_i];
+      clearInterval(timer.timer);
+    }
+  }
+  return gon._timers = {};
+};


### PR DESCRIPTION
### Use case

When using `gon.watch` and `turbolinks` together, your `gon.watch` callbacks will continue to fire even when you switch pages.  With `gon.unwatchAll()` it becomes trivial to add an event handler to the page change event that clears all your watchers.

``` coffeescript
$(document).on 'page:before-unload', ->
  gon.unwatchAll()
```
