### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Old readme available in [./README_old.md](https://github.com/gazay/gon/blob/mast
   ...
 ```
 
+For rails 4:
+``` erb
+  <%= Gon::Base.render_data({}) %>
+  ...
+```
+
+
+
 You can pass some [options](https://github.com/gazay/gon/wiki/Options)
 to `include_gon` method.
 


### PR DESCRIPTION
@gazay The reason for this change is that in rails4 the "<%= include_gon %>" throws 'gon not found' error. 
I was facing this issue with my rails 4.1 app. And it wasted my time a lot. I would suggest that for now, if we can add the solution given in #90 in the readme file will help a lot to others.