### PR TITLE
Delete dead link at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,6 @@ in modern web applications!
 
 ### More details about configuration and usage you can find in [gon wiki](https://github.com/gazay/gon/wiki)
 
-Old readme available in [./README_old.md](https://github.com/gazay/gon/blob/master/README_old.md)
-
-
 `app/views/layouts/application.html.erb`
 
 ``` erb


### PR DESCRIPTION
The reason for this change is that README_old.md is deleted at 1cb7c5a039f269bd5b58264fab16b1a4e4d2ca3f.