### PR TITLE
Simplify rendering API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ in modern web applications!
 
 For rails 4:
 ``` erb
-  <%= Gon::Base.render_data({}) %>
+  <%= Gon::Base.render_data %>
   ...
 ```
 

--- a/lib/gon/base.rb
+++ b/lib/gon/base.rb
@@ -18,7 +18,7 @@ class Gon
 
     class << self
 
-      def render_data(options)
+      def render_data(options = {})
         _o = define_options(options)
 
         script = formatted_data(_o)


### PR DESCRIPTION
Why do we suggest calling `Gon::Base.render_data({})`
since we can call `Gon::Base.render_data`?