### PR TITLE
Remove rubyforge_project option from .gemspec

### DIFF
--- a/gon.gemspec
+++ b/gon.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Get your Rails variables in your JS}
   s.description = %q{If you need to send some data to your js files and you don't want to do this with long way trough views and parsing - use this force!}
 
-  s.rubyforge_project = 'gon'
-
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ['lib']
   s.add_dependency 'actionpack', '>= 2.3.0'


### PR DESCRIPTION
rubyforge_project option is deprecated.