### PR TITLE
Use 'need_tag' as option name to prevent calling 'tag' method

### DIFF
--- a/lib/gon/base.rb
+++ b/lib/gon/base.rb
@@ -23,7 +23,7 @@ class Gon
 
         script = formatted_data(_o)
         script = Gon::Escaper.escape_unicode(script)
-        script = Gon::Escaper.javascript_tag(script, _o.type, _o.cdata, _o.nonce) if _o.tag
+        script = Gon::Escaper.javascript_tag(script, _o.type, _o.cdata, _o.nonce) if _o.need_tag
 
         script.html_safe
       end
@@ -36,9 +36,8 @@ class Gon
         VALID_OPTION_DEFAULTS.each do |opt_name, default|
           _o.send("#{opt_name}=", options.fetch(opt_name, default))
         end
-        _o.watch     = options[:watch] || !Gon.watch.all_variables.empty?
-        _o.tag       = _o.need_tag
-        _o.cameled   = _o.camel_case
+        _o.watch   = options[:watch] || !Gon.watch.all_variables.empty?
+        _o.cameled = _o.camel_case
 
         _o
       end


### PR DESCRIPTION
I try to use gon v6.0.1 with Rails v4.2.3. In my app, I met following error:
```
ActionView::Template::Error: wrong number of arguments (0 for 1..4)
    /Users/june29/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/actionview-4.2.3/lib/action_view/helpers/tag_helper.rb:74:in `tag'
    /Users/june29/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/gon-6.0.1/lib/gon/base.rb:26:in `render_data'
    /Users/june29/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/gon-6.0.1/lib/gon/helpers.rb:5:in `include_gon'
    /Users/june29/path/to/myapp/app/views/layouts/application.html.erb:29:in
...
```

The code `_o.tag` on this line calls `tag` method defined in ActionView.

```ruby
script = Gon::Escaper.javascript_tag(script, _o.type, _o.cdata, _o.nonce) if _o.tag
```

So I want to rename option `tag` to solve this problem.