### PR TITLE
Variable names are camelCased

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ gem line to your Gemfile and do the following:
   2. In your js you get this by
 
     ``` js
-    gon.variable_name
+    gon.variableName
     ```
 
   3. profit?


### PR DESCRIPTION
Variable names which use underscore in Rails will be camelCased in JS.
Maybe you should warn (or err) about undefined variables.
The README was misleading. There should be something about it somewhere.