### PR TITLE
DEPRECATION WARNING: env is deprecated and will be removed from Rails 5.0

### DIFF
--- a/lib/gon/helpers.rb
+++ b/lib/gon/helpers.rb
@@ -29,7 +29,7 @@ class Gon
   module ControllerHelpers
     def gon
       if wrong_gon_request?
-        gon_request = Request.new(env)
+        gon_request = Request.new(request.env)
         gon_request.id = gon_request_uuid
         RequestStore.store[:gon] = gon_request
       end


### PR DESCRIPTION
[this commit]( https://github.com/rails/rails/commit/05934d24aff62d66fc62621aa38dae6456e276be) deprecated `env` in favor of `request.env` 