### PR TITLE
Fix code highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ gem line to your Gemfile and do the following:
 
   1. Write variables by
 
-    ``` ruby
+   ``` ruby
     gon.variable_name = variable_value
 
     # or new syntax
@@ -55,13 +55,13 @@ gem line to your Gemfile and do the following:
     })
 
     gon.push(any_object) # any_object with respond_to? :each_pair
-    ```
+   ```
 
   2. In your js you get this by
 
-    ``` js
+   ``` js
     gon.variable_name
-    ```
+   ```
 
   3. profit?
 


### PR DESCRIPTION
GHM spec [1] says that 'A fenced code block begins with a code fence, indented
no more than three spaces', so highlighting is broken after GitHub switched to
the new markdown parser [2]

[1] https://github.github.com/gfm/#info-string
[2] https://githubengineering.com/a-formal-spec-for-github-markdown/