### PR TITLE
Fix keys cache

### DIFF
--- a/lib/gon/base.rb
+++ b/lib/gon/base.rb
@@ -124,7 +124,7 @@ class Gon
 
       def convert_key(key, camelize)
         cache = RequestStore.store[:gon_keys_cache] ||= {}
-        cache[key] ||= camelize ? key.to_s.camelize(:lower) : key.to_s
+        cache["#{key}_#{camelize}"] ||= camelize ? key.to_s.camelize(:lower) : key.to_s
       end
 
     end

--- a/spec/gon/basic_spec.rb
+++ b/spec/gon/basic_spec.rb
@@ -159,6 +159,16 @@ describe Gon do
       )
     end
 
+    it 'outputs correct key with camel_case option set alternately ' do
+      Gon.test_hash = 1
+      @base.include_gon(camel_case: true)
+
+      expect(@base.include_gon(camel_case: false)).to eq(
+                                 wrap_script('window.gon={};' +
+                                   'gon.test_hash=1;')
+      )
+    end
+
     it 'outputs correct js with an integer and without tag' do
       Gon.int = 1
       expect(@base.include_gon(need_tag: false)).to eq( \


### PR DESCRIPTION
The keys cache was store just by the key, which caused `camelize` option
to be ignored if the value for the key was already in cache.

According to my tests, the performance drop is marginal.

```
Warming up --------------------------------------
            original   578.000  i/100ms
         fixed cache   589.000  i/100ms
Calculating -------------------------------------
            original      5.618k (± 9.8%) i/s -     28.322k in   5.098340s
         fixed cache      5.540k (±11.3%) i/s -     27.683k in   5.068007s

Comparison:
            original:     5617.6 i/s
         fixed cache:     5540.2 i/s - same-ish: difference falls within error
```

The code I used to run benchmark

```ruby
require 'benchmark/ips'

it 'is still performant', do    
  Gon.int_cased = 1
    Benchmark.ips do |x|      
    x.config(:time => 5, :warmup => 2)         

      x.report('original') { @base.include_gon(camel_case: true) }
      x.report('fixed cache') { @base.include_gon(camel_case: true, fix_cache: true) }

      x.compare!
  end
end

...

js_key = convert_key(key, _o.cameled, _o.fix_cache)

....

def convert_key(key, camelize, fix_cache)
  cache = RequestStore.store[:gon_keys_cache] ||= {}
  if fix_cache then
    cache["#{key}_#{camelize}"] ||= camelize ? key.to_s.camelize(:lower) : key.to_s
  else
    cache[key] ||= camelize ? key.to_s.camelize(:lower) : key.to_s
  end
end
```

