### PR TITLE
fix overriding ActionController::Live with test_behaviour when not test mode

### DIFF
--- a/lib/gon.rb
+++ b/lib/gon.rb
@@ -20,7 +20,7 @@ unless ActionDispatch::Request.public_instance_methods.include?(:uuid)
   require 'gon/compatibility/old_rails'
 end
 
-require 'gon/spec_helpers'
+require 'gon/spec_helpers' if Rails.env.test?
 
 class Gon
   class << self

--- a/lib/gon.rb
+++ b/lib/gon.rb
@@ -20,7 +20,7 @@ unless ActionDispatch::Request.public_instance_methods.include?(:uuid)
   require 'gon/compatibility/old_rails'
 end
 
-require 'gon/spec_helpers' if Rails.env.test?
+require 'gon/spec_helpers' if 'test' == ENV['RAILS_ENV']
 
 class Gon
   class << self


### PR DESCRIPTION
This fixes the (unintentional?) loading of `ActionController::TestCase::Behavior` in non-test environment, which breaks the method [`ActionController::Live#new_controller_thread`](https://github.com/rails/rails/blob/v5.1.5/actionpack/lib/action_controller/test_case.rb#L20)  and makes the server to hang.

basic demo project to show the issue:  https://github.com/rcugut/xlsxtream_playground
