### PR TITLE
Autoload test classes only in test env

### DIFF
--- a/lib/gon/spec_helpers.rb
+++ b/lib/gon/spec_helpers.rb
@@ -24,7 +24,7 @@ class Gon
   end
 end
 
-if defined?(ActionController::TestCase::Behavior)
+if ENV['RAILS_ENV'] == 'test' && defined?(ActionController::TestCase::Behavior)
   ActionController::TestCase::Behavior.send :include, Gon::SpecHelper::Rails
 end
 


### PR DESCRIPTION
Hi @gazay!

There are some problems with LiveControllers. When we lookup for this constant, rails will try to `autoload` it. But `ActionController::TestCase` patches method of `Live` instance: `new_controller_thread`, which creates a new thread for a response to connection, because in the test environment can be problems with database connections. Therefore in the development environment, `LiveController` works in the same thread, as the main rails thread, so it can't respond by chunks. It just writes all response to buffer, and respond at the end of the action.

So, my solution is just lookup this constant only if `Rails` in `test` environment.