### PR TITLE
ActionView::Base and ActionController::Base should be loaded inside ActiveSupport.on_load hook

### DIFF
--- a/lib/gon/helpers.rb
+++ b/lib/gon/helpers.rb
@@ -52,5 +52,9 @@ class Gon
   end
 end
 
-ActionView::Base.send :include, Gon::ViewHelpers
-ActionController::Base.send :include, Gon::ControllerHelpers
+ActiveSupport.on_load :action_view do
+  ActionView::Base.send :include, Gon::ViewHelpers
+end
+ActiveSupport.on_load :action_controller do
+  ActionController::Base.send :include, Gon::ControllerHelpers
+end


### PR DESCRIPTION
Currently, requiring `gon` immediately requires `ActionView::Base` and `ActionController::Base` [here](https://github.com/gazay/gon/blob/96e9a6469bf9add680b9514b369ec2e60282b5b8/lib/gon/helpers.rb#L55-L56) for monkey-patching, which results in loading almost everything within actionview and actionpack, and also triggers all `:action_view` and `:action_controller` on_load hooks that are defined via apps and bundled plugins.

For postponing those heavy loads, Rails equips `ActiveSupport.on_load` mechanism as described here. https://guides.rubyonrails.org/engines.html#active-support-on-load-hooks
With this hooks properly configured, applications can defer loading Action*::Base until they actually use them, so that they can boot the app faster where they don't use them, e.g. when starting up the Rails console, running model unit tests, etc.