### PR TITLE
Suppress Ruby 2.7's warning about keyword arguments

### DIFF
--- a/lib/gon/spec_helpers.rb
+++ b/lib/gon/spec_helpers.rb
@@ -5,7 +5,7 @@ class Gon
 
       module ClassMethods
         module GonSession
-          def process(*)
+          def process(*, **)
             # preload threadlocal & store controller instance
             if controller.is_a? ActionController::Base
               controller.gon


### PR DESCRIPTION
Suppress Ruby 2.7's warning about keyword arguments.

cf. https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/