### PR TITLE
fix for ruby3

### DIFF
--- a/lib/gon/spec_helpers.rb
+++ b/lib/gon/spec_helpers.rb
@@ -5,7 +5,7 @@ class Gon
 
       module ClassMethods
         module GonSession
-          def process(*, **)
+          def process(...)
             # preload threadlocal & store controller instance
             if controller.is_a? ActionController::Base
               controller.gon


### PR DESCRIPTION
This solves `wrong number of arguments (given 2, expected 1)` errors