### PR TITLE
Explicitly require ostruct

### DIFF
--- a/gon.gemspec
+++ b/gon.gemspec
@@ -20,6 +20,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n', '>= 0.7'
   s.add_dependency 'request_store', '>= 1.0'
   s.add_dependency 'multi_json'
+  if RUBY_VERSION >= '3.5.0'
+    s.add_dependency 'ostruct'
+  end
   s.add_development_dependency 'rabl', '0.11.3'
   s.add_development_dependency 'rabl-rails'
   s.add_development_dependency 'rspec', '>= 3.0'


### PR DESCRIPTION
```
rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/gon-6.4.0/lib/gon/base.rb:1: 
warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0. You can add ostruct to your Gemfile or gemspec to silence this warning.
```

closes #270