### PR TITLE
Replace destructive string concatenation with array join in form…

### DIFF
--- a/lib/gon/base.rb
+++ b/lib/gon/base.rb
@@ -43,7 +43,7 @@ class Gon
       end
 
       def formatted_data(_o)
-        script = ''
+        script = []
         before, after = render_wrap(_o)
         script << before
 
@@ -52,7 +52,7 @@ class Gon
         script << (render_watch(_o) || '')
 
         script << after
-        script
+        script.join
       end
 
       def render_wrap(_o)


### PR DESCRIPTION
## Background
Ruby 3.4 will soon freeze all string literals by default, and using destructive methods like << on a literal empty string ('') will trigger warnings today and raise a FrozenError in the future. In Gon::Base#formatted_data, we were building up the output script via script = '' followed by script << …, which is incompatible with the upcoming frozen-string behavior.

## Changes

Replaced the mutable-literal approach:

script = '' → script = []

All script << fragment calls → script << fragment

At the end of the method, return the assembled string via script.join instead of the mutated script