### PR TITLE
Remove ostruct dependency

### DIFF
--- a/lib/gon/base.rb
+++ b/lib/gon/base.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'ostruct'
-
 class Gon
   module Base
     VALID_OPTION_DEFAULTS = {
@@ -18,6 +16,9 @@ class Gon
         nonce: nil
     }
 
+    Option = Struct.new(:cameled, *VALID_OPTION_DEFAULTS.keys)
+    private_constant :Option
+
     class << self
 
       def render_data(options = {})
@@ -33,7 +34,7 @@ class Gon
       private
 
       def define_options(options)
-        _o = OpenStruct.new
+        _o = Option.new
 
         VALID_OPTION_DEFAULTS.each do |opt_name, default|
           _o.send("#{opt_name}=", options.fetch(opt_name, default))

--- a/spec/gon/jbuilder_spec.rb
+++ b/spec/gon/jbuilder_spec.rb
@@ -22,7 +22,7 @@ describe Gon do
       it 'render json from jbuilder template with locals' do
         Gon.jbuilder :template => 'spec/test_data/sample_with_locals.json.jbuilder',
                      :controller => controller,
-                     :locals => { :some_local => 1234, :some_complex_local => OpenStruct.new(:id => 1234) }
+                     :locals => { :some_local => 1234, :some_complex_local => Struct.new(:id).new(1234) }
         expect(Gon.some_local).to eq(1234)
         expect(Gon.some_complex_local_id).to eq(1234)
       end


### PR DESCRIPTION
fix #270 

ostruct has become a bundled gem, so the following warning is output from Ruby 3.4:

```
/path/to/ruby/gems/3.4.0/gems/gon-6.4.0/lib/gon/base.rb:1:
warning: ostruct was loaded from the standard library, but will no
longer be part of the default gems starting from Ruby 3.5.0. You can
add ostruct to your Gemfile or gemspec to silence this warning.
```

We will change to use Struct instead and remove the dependency.