### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/gon.gemspec
+++ b/gon.gemspec
@@ -13,7 +13,12 @@ Gem::Specification.new do |s|
   s.summary     = %q{Get your Rails variables in your JS}
   s.description = %q{If you need to send some data to your js files and you don't want to do this with long way trough views and parsing - use this force!}
 
-  s.files         = `git ls-files`.split("\n")
+  s.files         = Dir.glob('lib/**/*') + Dir.glob('coffee/**/*') + Dir.glob('js/**/*') + [
+    'CHANGELOG.md',
+    'LICENSE',
+    'README.md'
+  ]
+
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.2.0'
   s.add_dependency 'actionpack', '>= 3.0.20'


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure
```bash
$ gem build -o before.tar.gz

$ git switch reduce-gem-size

$ gem build -o after.tar.gz

$ du -sh before after
 156K	before.tar.gz
 20K	after.tar.gz
 ```
 
 |          | before       | after       | saved              |
|----------|--------------|-------------|--------------------|
| **size** | 156K         | 20K         | **-136K (⏷ -87.18%)** |

 
###  whitch files was deleted?

```diff
  data
-├── .github
-│   ├── FUNDING.yml
-│   └── workflows
-│       └── ci.yml
-├── .gitignore
 ├── CHANGELOG.md
 ├── coffee
 │   └── watch.coffee
-├── doc
-│   ├── logo_small.png
-│   ├── logo.png
-│   └── top_sample.png
-├── Gemfile
-├── gon.gemspec
 ├── js
 │   └── watch.js
 ├── lib
 │   ├── gon
 │   │   ├── base.rb
 │   │   ├── compatibility
 │   │   │   └── old_rails.rb
 │   │   ├── env_finder.rb
 │   │   ├── escaper.rb
 │   │   ├── global.rb
 │   │   ├── helpers.rb
 │   │   ├── jbuilder
 │   │   │   └── parser.rb
 │   │   ├── jbuilder.rb
 │   │   ├── json_dumper.rb
 │   │   ├── rabl.rb
 │   │   ├── request.rb
 │   │   ├── spec_helpers.rb
 │   │   ├── version.rb
 │   │   └── watch.rb
 │   └── gon.rb
 ├── LICENSE
-├── Rakefile
 ├── README.md
-└── spec
-    ├── gon
-    │   ├── basic_spec.rb
-    │   ├── global_spec.rb
-    │   ├── jbuilder_spec.rb
-    │   ├── rabl_spec.rb
-    │   ├── templates_spec.rb
-    │   ├── thread_spec.rb
-    │   └── watch_spec.rb
-    ├── spec_helper.rb
-    └── test_data
-        ├── _sample_partial.json.jbuilder
-        ├── sample_rabl_rails.rabl
-        ├── sample_url_helpers.json.jbuilder
-        ├── sample_with_controller_method.json.jbuilder
-        ├── sample_with_helpers_rabl_rails.rabl
-        ├── sample_with_helpers.json.jbuilder
-        ├── sample_with_helpers.rabl
-        ├── sample_with_locals.json.jbuilder
-        ├── sample_with_partial.json.jbuilder
-        ├── sample.json.jbuilder
-        └── sample.rabl
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)