### PR TITLE
Replace deprecated File.exists? with File.exist?

### DIFF
--- a/lib/gon/jbuilder/parser.rb
+++ b/lib/gon/jbuilder/parser.rb
@@ -110,9 +110,9 @@ class Gon
       end
 
       def path_with_ext(path)
-        return path if File.exists?(path)
-        return "#{path}.jbuilder" if File.exists?("#{path}.jbuilder")
-        return "#{path}.json.jbuilder" if File.exists?("#{path}.json.jbuilder")
+        return path if File.exist?(path)
+        return "#{path}.jbuilder" if File.exist?("#{path}.jbuilder")
+        return "#{path}.json.jbuilder" if File.exist?("#{path}.json.jbuilder")
       end
 
       def find_partials(lines = [])


### PR DESCRIPTION
`File.exists?` was removed in Ruby 3.2, so replace it with `File.exist?`.
see: https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/