### PR TITLE
Add .rspec to run individual test files

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper


### PR DESCRIPTION
When running bundle exec rake, [spec/spec_helper.rb is required automatically](https://github.com/gazay/gon/blob/14fccbb1b3890f63b09929939935673065ee7247/Rakefile#L9), but it’s not the case with bundle exec rspec, which causes tests to fail. Although adding `--require=spec_helper` works, it’s not developer-friendly. Updated the config so that spec/spec_helper.rb is required automatically when using the rspec command.
