### PR TITLE
Stop stubbing Rails version in tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,20 +1,8 @@
 # frozen_string_literal: true
 
 require 'rails/railtie'
-# We don't require rails for specs, but jbuilder works only in rails.
-# And it checks version of rails. I've decided to configure jbuilder for rails v4
-module Rails
-  module VERSION
-    MAJOR = 4
-  end
-
-  def self.version
-    '4.2.0'
-  end
-end
-
+require 'rails/version' # jbuilder <= 2.13.0 checks rails version
 require 'gon'
-
 require 'jbuilder'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Up to version 2.13.0, jbuilder switches behavior based on `RAILS::VERSION::MAJOR`. Although no versions above 2.13.0 have been released yet, [this commit](https://github.com/rails/jbuilder/commit/a4dc35ef73b655e0af6f97bef2bdd61b0cde5d37) removed references to `Rails::VERSION::MAJOR` from jbuilder’s application code. Future versions of jbuilder won’t need to care about the Rails version, but we might still run tests with older jbuilder versions, so it's safer to keep the version reference.

Since jbuilder behavior depends on the Rails version, it's not ideal to stub the Rails version in tests. Instead, I updated the `Gemfile` to explicitly set the `railties` version.
