### PR TITLE
Make broad-scope hooks and method definitions active only where needed

### DIFF
--- a/spec/gon/basic_spec.rb
+++ b/spec/gon/basic_spec.rb
@@ -1,13 +1,22 @@
 # frozen_string_literal: true
 
 describe Gon do
+  def wrap_script(content, cdata=true)
+    script = +"<script>"
+    script << "\n//<![CDATA[\n" if cdata
+    script << content
+    script << "\n//]]>\n" if cdata
+    script << '</script>'
+  end
 
   before(:each) do
+    RequestStore.store[:gon] = Gon::Request.new({})
+    @request = RequestStore.store[:gon]
+    allow(Gon).to receive(:current_gon).and_return(@request)
     Gon.clear
   end
 
   describe '#all_variables' do
-
     it 'returns all variables in hash' do
       Gon.a = 1
       Gon.b = 2
@@ -82,17 +91,15 @@ describe Gon do
         end
       end
     end
-
   end
 
   describe '#include_gon' do
-
     before(:each) do
       Gon::Request.
-        instance_variable_set(:@request_id, request.object_id)
+        instance_variable_set(:@request_id, @request.object_id)
       expect(ActionView::Base.instance_methods).to include(:include_gon)
       @base = ActionView::Base.new(nil,{}, nil)
-      @base.request = request
+      @base.request = @request
     end
 
     it 'outputs correct js with an integer' do
@@ -243,18 +250,15 @@ describe Gon do
       it 'outputs correct js with init' do
         expect(@base.include_gon(init: true)).to eq(wrap_script('window.gon={};'))
       end
-
     end
-
   end
 
   describe '#include_gon_amd' do
-
     before(:each) do
       Gon::Request.
-        instance_variable_set(:@request_id, request.object_id)
+        instance_variable_set(:@request_id, @request.object_id)
       @base = ActionView::Base.new(nil, {}, nil)
-      @base.request = request
+      @base.request = @request
     end
 
     it 'is included in ActionView::Base as a helper' do
@@ -294,7 +298,6 @@ describe Gon do
   end
 
   describe '#check_for_rabl_and_jbuilder' do
-
     let(:controller) { ActionController::Base.new }
 
     it 'should be able to handle constants array (symbols)' do

--- a/spec/gon/global_spec.rb
+++ b/spec/gon/global_spec.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 describe Gon::Global do
-
   before(:each) do
+    RequestStore.store[:gon] = Gon::Request.new({})
+    @request = RequestStore.store[:gon]
+    allow(Gon).to receive(:current_gon).and_return(@request)
     Gon::Global.clear
     Gon::Request.instance_variable_set(:@request_env, nil)
   end
 
   describe '#all_variables' do
-
     it 'returns all variables in hash' do
       Gon.global.a = 1
       Gon.global.b = 2
@@ -27,16 +28,14 @@ describe Gon::Global do
       Gon.global.hash_w_array = { :a => [2, 3] }
       Gon.global.klass        = Hash
     end
-
   end
 
   describe '#include_gon' do
-
     before(:each) do
       Gon.clear
       expect(ActionView::Base.instance_methods).to include(:include_gon)
       @base = ActionView::Base.new(nil, {}, nil)
-      @base.request = request
+      @base.request = @request
     end
 
     it 'outputs correct js with an integer' do
@@ -121,7 +120,6 @@ describe Gon::Global do
   end
 
   context 'with jbuilder and rabl' do
-
     before :each do
       controller.instance_variable_set('@objects', objects)
     end
@@ -144,6 +142,5 @@ describe Gon::Global do
       expect { Gon.global.rabl }.to raise_error(RuntimeError)
       expect { Gon.global.jbuilder }.to raise_error(RuntimeError)
     end
-
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,22 +5,5 @@ require 'rails/version' # jbuilder <= 2.13.0 checks rails version
 require 'gon'
 require 'jbuilder'
 
-RSpec.configure do |config|
-  config.before(:each) do
-    RequestStore.store[:gon] = Gon::Request.new({})
-    @request = RequestStore.store[:gon]
-    allow(Gon).to receive(:current_gon).and_return(@request)
-  end
-end
-
-def request
-  @request ||= double 'request', :env => {}
-end
-
-def wrap_script(content, cdata=true)
-  script = +"<script>"
-  script << "\n//<![CDATA[\n" if cdata
-  script << content
-  script << "\n//]]>\n" if cdata
-  script << '</script>'
+RSpec.configure do |_config|
 end


### PR DESCRIPTION
The before hook that was applied globally was actually only required in global_spec.rb and basic_spec.rb. Applying it globally forced unnecessary considerations in unrelated tests, reducing readability, so it was moved to where it’s actually needed.

Similarly, the wrap_script method was only used in basic_spec.rb, so it is now defined directly within basic_spec.rb.
