### PR TITLE
Fix a failure in thread_safe tests when using truffleruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
         include:
           - ruby-version: head
             continue-on-error: true
-          - ruby-version: truffleruby
-            continue-on-error: true
 
     steps:
     - uses: actions/checkout@v4

--- a/spec/gon/thread_spec.rb
+++ b/spec/gon/thread_spec.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
+require 'action_dispatch/testing/test_request'
 
 class GonTestWorker
   include Gon::ControllerHelpers
 
   def request
     @request ||= ActionDispatch::TestRequest.create
-  end
-
-  def env
-    request.env
   end
 
   def execute
@@ -23,10 +20,6 @@ class GonTestWorker
 end
 
 describe 'threading behaviour' do
-  before do
-    allow(Gon).to receive(:current_gon).and_call_original
-  end
-
   it 'is threadsafe' do
     threads = []
     10.times do


### PR DESCRIPTION
Fix #253

Although not thoroughly investigated, the error was likely caused by ActionDispatch::TestRequest being autoloaded concurrently. Requiring ActionDispatch::TestRequest beforehand resolves the issue.

Along with this change, I removed unnecessary methods and meaningless stubs.
