### PR TITLE
Remove no longer used `@request_env` in tests

### DIFF
--- a/spec/gon/basic_spec.rb
+++ b/spec/gon/basic_spec.rb
@@ -189,7 +189,7 @@ describe Gon do
     it 'outputs correct js without variables, without tag and gon init if before there was data' do
       Gon::Request.
         instance_variable_set(:@request_id, 123)
-      Gon::Request.instance_variable_set(:@request_env, { 'gon' => { :a => 1 } })
+      Gon::Request.instance_variable_set(:@env, { 'gon' => { :a => 1 } })
       expect(@base.include_gon(need_tag: false, init: true)).to eq( \
                                   'window.gon={};'
       )

--- a/spec/gon/global_spec.rb
+++ b/spec/gon/global_spec.rb
@@ -6,7 +6,6 @@ describe Gon::Global do
     @request = RequestStore.store[:gon]
     allow(Gon).to receive(:current_gon).and_return(@request)
     Gon::Global.clear
-    Gon::Request.instance_variable_set(:@request_env, nil)
   end
 
   describe '#all_variables' do


### PR DESCRIPTION
`@request_env` was removed in [this commit](https://github.com/gazay/gon/commit/1f0ba1d45c364efe1d970b08bf208f91078000fe), but it was still present in the tests. Updated the tests to match the current implementation.
