### PR TITLE
Remove useless stubs in tests

### DIFF
--- a/spec/gon/basic_spec.rb
+++ b/spec/gon/basic_spec.rb
@@ -12,7 +12,6 @@ describe Gon do
   before(:each) do
     RequestStore.store[:gon] = Gon::Request.new({})
     @request = RequestStore.store[:gon]
-    allow(Gon).to receive(:current_gon).and_return(@request)
     Gon.clear
   end
 

--- a/spec/gon/global_spec.rb
+++ b/spec/gon/global_spec.rb
@@ -4,7 +4,6 @@ describe Gon::Global do
   before(:each) do
     RequestStore.store[:gon] = Gon::Request.new({})
     @request = RequestStore.store[:gon]
-    allow(Gon).to receive(:current_gon).and_return(@request)
     Gon::Global.clear
   end
 


### PR DESCRIPTION
We don't need stubs for `Gon.current_gon` since it returns `RequestStore.store[:gon]`, which we already set.
