### PR TITLE
Update CHANGELOG for version 6.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
-## [Unreleased]
+## 6.5.0 and later
+
+For changes from version 6.5.0 onwards, please check the [GitHub Releases page](https://github.com/gazay/gon/releases).
 
 ## [6.4.0] - 2020-09-18
 ### Security


### PR DESCRIPTION
From now on, we’ll use the GitHub Release page to reduce the effort of updating the CHANGELOG.
