### PR TITLE
Add ostruct gem as explicit dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem ENV['RABL_GEM'] || 'rabl'
 gem 'concurrent-ruby', '< 1.3.5' if ENV['RAILS_VERSION'] && ENV['RAILS_VERSION'].to_f < 7.1
 gem 'loofah', '2.20.0' if RUBY_VERSION < '2.5'
 gem 'request_store' if ENV['RAILS_VERSION'] && ENV['RAILS_VERSION'].to_f < 5.2
+gem 'ostruct', '~> 0.6' if RUBY_VERSION < '4.0'
 
 if ENV['RAILS_VERSION']
   gem 'railties', "~> #{ENV['RAILS_VERSION']}.0"


### PR DESCRIPTION
ostruct is no longer part of the default gems starting from Ruby 4.0.0.