### PR TITLE
MultiJson.dump is deprecated

### DIFF
--- a/gon.gemspec
+++ b/gon.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionpack', '>= 3.0.20'
   s.add_dependency 'activesupport'
   s.add_dependency 'i18n', '>= 0.7'
-  s.add_dependency 'multi_json'
+  s.add_dependency 'multi_json', '>= 1.21.0'
   s.add_development_dependency 'rspec', '>= 3.0'
   s.add_development_dependency 'jbuilder'
   s.add_development_dependency 'railties'

--- a/lib/gon/json_dumper.rb
+++ b/lib/gon/json_dumper.rb
@@ -13,7 +13,7 @@ class Gon
     }
 
     def self.dump(object)
-      dumped_json = MultiJson.dump object,
+      dumped_json = MultiJSON.generate object,
         mode: :compat, escape_mode: :xss_safe, time_format: :ruby
       escape(dumped_json)
     end


### PR DESCRIPTION
```
The MultiJson constant is deprecated and will be removed in v2.0. Use MultiJSON instead.
MultiJSON.dump is deprecated and will be removed in v2.0. Use MultiJSON.generate instead.
```

ref.) https://github.com/sferik/multi_json/commit/112d0afbccbbb4ca133723bddb66750c1ce54aaa