### PR TITLE
Support both old and new multi_json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,3 +345,32 @@ jobs:
           cat error.log
           exit 1
         fi
+
+  test-multi-json-compatibility:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        multi-json-version:
+          - '1.20.1'
+          - '~> 1.21'
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Ruby 3.2
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
+
+    - name: Test multi_json ${{ matrix.multi-json-version }}
+      env:
+        BUNDLE_GEMFILE: multi_json_compat.gemfile
+        MULTI_JSON_VERSION: ${{ matrix.multi-json-version }}
+      run: |
+        cat <<EOF > $BUNDLE_GEMFILE
+        source 'https://rubygems.org'
+        gem 'multi_json', '$MULTI_JSON_VERSION'
+        gemspec
+        EOF
+        bundle install
+        bundle exec rspec --require ./spec/spec_helper spec/gon/json_dumper_spec.rb

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ usage gon.global.
 ## Speed up Gon
 
 You can use any [JSON Engine](https://github.com/sferik/multi_json#supported-json-engines) you want.
-Gon uses `MultiJson` with autodetect mode, so all you need is just require your JSON library.
+Gon uses multi_json with autodetect mode, so all you need is just require your JSON library.
 
 ## Current Maintainers
 

--- a/lib/gon/json_dumper.rb
+++ b/lib/gon/json_dumper.rb
@@ -13,8 +13,13 @@ class Gon
     }
 
     def self.dump(object)
-      dumped_json = MultiJson.dump object,
-        mode: :compat, escape_mode: :xss_safe, time_format: :ruby
+      options = { mode: :compat, escape_mode: :xss_safe, time_format: :ruby }
+      dumped_json = if defined?(MultiJSON)
+        MultiJSON.generate(object, options)
+      else
+        MultiJson.dump(object, options)
+      end
+
       escape(dumped_json)
     end
 

--- a/spec/gon/json_dumper_spec.rb
+++ b/spec/gon/json_dumper_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+describe Gon::JsonDumper do
+  it 'generates JSON with script-unsafe characters escaped' do
+    object = {
+      string: "<script>&\u2028\u2029",
+      number: 1,
+      boolean: true,
+      nothing: nil
+    }
+    expected = '{"string":"\\u003cscript\\u003e\\u0026\\u2028\\u2029",' \
+      '"number":1,"boolean":true,"nothing":null}'
+
+    expect(described_class.dump(object)).to eq(expected)
+  end
+end


### PR DESCRIPTION
multi_json changes its API from v2 ( https://github.com/sferik/multi_json/commit/112d0afbccbbb4ca133723bddb66750c1ce54aaa ), so support it.

Some users likely use gon with old Ruby or Rails versions. If we raise the supported multi_json version, Ruby 3.2 or later becomes required ( https://github.com/sferik/multi_json/blob/9ae5a429e519fb70440833d8b8968a2123da9098/multi_json.gemspec#L19 ). So do not raise the multi_json dependency version, and make it work with both old and new multi_json.
