### PR TITLE
Add gon_variables helper for controller specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'concurrent-ruby', '< 1.3.5' if ENV['RAILS_VERSION'] && ENV['RAILS_VERSION']
 gem 'i18n', '< 1.15' if RUBY_VERSION < '3.2'
 gem 'loofah', '2.20.0' if RUBY_VERSION < '2.5'
 gem 'request_store' if ENV['RAILS_VERSION'] && ENV['RAILS_VERSION'].to_f < 5.2
+gem 'test-unit', '~> 3.0' if ENV['RAILS_VERSION'] == '3.2'
 
 if ENV['RAILS_VERSION']
   gem 'railties', "~> #{ENV['RAILS_VERSION']}.0"

--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ gon.your_array # > [1, 2, 123]
 # gon.clear # gon.all_variables now is {}
 ```
 
+### Testing gon variables in controller specs
+
+In controller specs, Rails can clear `ActiveSupport::CurrentAttributes`
+after the request is processed. Use `gon_variables` to read the gon values
+assigned during the last request:
+
+``` ruby
+get :show
+expect(gon_variables['foo']).to eq('bar')
+```
+
 Access the variables from your JavaScript file:
 
 ``` js

--- a/lib/gon/spec_helpers.rb
+++ b/lib/gon/spec_helpers.rb
@@ -7,14 +7,32 @@ class Gon
 
       module ClassMethods
         module GonSession
-          def process(*, **)
+          def process(*args, **kwargs)
+            @gon_request = nil
+
             # preload threadlocal & store controller instance
-            if controller.is_a? ActionController::Base
-              controller.gon
+            if gon_controller.is_a? ActionController::Base
+              gon_controller.gon
+              @gon_request = Gon.send(:current_gon)
               Gon.send(:current_gon).env[Gon::EnvFinder::ENV_CONTROLLER_KEY] =
-               controller
+               gon_controller
             end
-            super
+
+            if ActionPack::VERSION::MAJOR < 4
+              super(*args.first(5))
+            else
+              super(*args, **kwargs)
+            end
+          end
+
+          def gon_variables
+            @gon_request ? @gon_request.gon : {}
+          end
+
+          private
+
+          def gon_controller
+            respond_to?(:controller) ? controller : @controller
           end
         end
 
@@ -29,4 +47,3 @@ end
 if ENV['RAILS_ENV'] == 'test' && defined?(ActionController::TestCase::Behavior)
   ActionController::TestCase::Behavior.send :include, Gon::SpecHelper::Rails
 end
-

--- a/spec/gon/spec_helpers_spec.rb
+++ b/spec/gon/spec_helpers_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'action_controller'
+require 'action_controller/test_case'
+
+describe Gon::SpecHelper::Rails do
+  let(:current) { Gon.const_get(:Current) }
+  let(:routes) do
+    ActionDispatch::Routing::RouteSet.new.tap do |routes|
+      routes.draw do
+        get 'show' => 'anonymous#show'
+        get 'show' => 'anonymous_controller#show'
+      end
+    end
+  end
+  let(:controller_class) do
+    routes = self.routes
+
+    Class.new(ActionController::Base) do
+      include routes.url_helpers
+
+      def show
+        gon.foo = 'bar'
+        render(ActionPack::VERSION::MAJOR >= 4 ? { plain: 'hello' } : { text: 'hello' })
+      end
+    end
+  end
+  let(:test_case_class) do
+    routes = self.routes
+    controller_class = self.controller_class
+
+    Class.new(ActionController::TestCase) do
+      include Gon::SpecHelper::Rails
+
+      tests controller_class
+
+      define_method(:setup) do
+        super()
+        @routes = routes
+      end
+
+      def test_show; end
+    end
+  end
+  let(:test_case) { test_case_class.new(:test_show) }
+
+  before do
+    current.gon = nil
+  end
+
+  after do
+    begin
+      test_case.before_teardown if test_case && test_case.respond_to?(:before_teardown)
+      test_case.teardown if test_case
+    ensure
+      current.gon = Gon::Request.new({})
+    end
+  end
+
+  def setup_test_case
+    test_case.before_setup if test_case.respond_to?(:before_setup)
+    test_case.setup
+    test_case.send(:setup_controller_request_and_response) if test_case.instance_variable_get(:@controller).nil?
+    test_case.after_setup if test_case.respond_to?(:after_setup)
+  end
+
+  describe '#gon_variables' do
+    it 'returns an empty hash before a request is processed' do
+      setup_test_case
+
+      expect(test_case.gon_variables).to eq({})
+    end
+
+    it 'returns gon variables assigned in an ActionController::TestCase request' do
+      setup_test_case
+
+      test_case.get(:show)
+
+      expect(test_case.response.status).to eq(200)
+      expect(test_case.response.body).to eq('hello')
+      expect(test_case.gon_variables).to eq({ 'foo' => 'bar' })
+    end
+
+    it 'returns gon variables after the current attributes are reset' do
+      setup_test_case
+
+      test_case.get(:show)
+      current.gon = nil
+
+      expect(Gon.all_variables).to eq({})
+      expect(test_case.gon_variables).to eq({ 'foo' => 'bar' })
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
+
+begin
+  require 'test/unit'
+  Test::Unit::AutoRunner.need_auto_run = false
+rescue LoadError
+end
+
 require 'active_support/all'
+Test::Unit::AutoRunner.need_auto_run = false if defined?(Test::Unit::AutoRunner)
+
 require 'rails/railtie'
 require 'rails/version' # jbuilder <= 2.13.0 checks rails version
 require 'gon'


### PR DESCRIPTION
Store the request-local Gon::Request during controller test processing so gon variables can be inspected after Rails clears CurrentAttributes.
