### PR TITLE
Fix CI issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in gon.gemspec
 gem ENV['RABL_GEM'] || 'rabl'
 gem 'concurrent-ruby', '< 1.3.5' if ENV['RAILS_VERSION'] && ENV['RAILS_VERSION'].to_f < 7.1
+gem 'i18n', '< 1.15' if RUBY_VERSION < '3.2'
 gem 'loofah', '2.20.0' if RUBY_VERSION < '2.5'
 gem 'request_store' if ENV['RAILS_VERSION'] && ENV['RAILS_VERSION'].to_f < 5.2
 


### PR DESCRIPTION
The i18n gem v1.5.0 depends on Ruby 3.1 or later, but it uses some Ruby 3.2+ features. This makes gon CI fail. Use i18n versions below v1.5.0 on Ruby 3.1 to make CI pass.

ref: https://github.com/ruby-i18n/i18n/pull/736
