### PR TITLE
Remove rabl-rails support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,293 +12,110 @@ jobs:
     strategy:
       matrix:
         include:
-          # Ruby 2.3 - Rails 3.2-5.2 ( rabl-rails supports Rails 4.2+)
+          # Ruby 2.3 - Rails 3.2-5.2
           - ruby-version: '2.3'
             rails-version: '3.2'
-            rabl-gem: 'rabl'
           - ruby-version: '2.3'
             rails-version: '4.2'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.3'
-            rails-version: '4.2'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '2.3'
             rails-version: '5.2'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.3'
-            rails-version: '5.2'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
 
           # Ruby 2.4 - Rails 3.x-5.2
           - ruby-version: '2.4'
             rails-version: '4.2'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.4'
-            rails-version: '4.2'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '2.4'
             rails-version: '5.2'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.4'
-            rails-version: '5.2'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
+
           # Ruby 2.5 - Rails 5.2-6.1
           - ruby-version: '2.5'
             rails-version: '5.2'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.5'
-            rails-version: '5.2'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '2.5'
             rails-version: '6.0'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.5'
-            rails-version: '6.0'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '2.5'
             rails-version: '6.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.5'
-            rails-version: '6.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
 
           # Ruby 2.6 - Rails 5.2-6.1
           - ruby-version: '2.6'
             rails-version: '5.2'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.6'
-            rails-version: '5.2'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '2.6'
             rails-version: '6.0'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.6'
-            rails-version: '6.0'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '2.6'
             rails-version: '6.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.6'
-            rails-version: '6.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
 
           # Ruby 2.7 - Rails 6.0-7.0
           - ruby-version: '2.7'
             rails-version: '6.0'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.7'
-            rails-version: '6.0'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '2.7'
             rails-version: '6.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.7'
-            rails-version: '6.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '2.7'
             rails-version: '7.0'
-            rabl-gem: 'rabl'
-          - ruby-version: '2.7'
-            rails-version: '7.0'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
 
           # Ruby 3.0 - Rails 6.1-7.1
           - ruby-version: '3.0'
             rails-version: '6.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.0'
-            rails-version: '6.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.0'
             rails-version: '7.0'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.0'
-            rails-version: '7.0'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.0'
             rails-version: '7.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.0'
-            rails-version: '7.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
 
           # Ruby 3.1 - Rails 6.1-7.1
           - ruby-version: '3.1'
             rails-version: '6.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.1'
-            rails-version: '6.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.1'
             rails-version: '7.0'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.1'
-            rails-version: '7.0'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.1'
             rails-version: '7.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.1'
-            rails-version: '7.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
 
           # Ruby 3.2 - Rails 7.0-8.1
           - ruby-version: '3.2'
             rails-version: '7.0'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.2'
-            rails-version: '7.0'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.2'
             rails-version: '7.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.2'
-            rails-version: '7.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.2'
             rails-version: '8.0'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.2'
-            rails-version: '8.0'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.2'
             rails-version: '8.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.2'
-            rails-version: '8.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
 
           # Ruby 3.3 - Rails 7.1-8.1
           - ruby-version: '3.3'
             rails-version: '7.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.3'
-            rails-version: '7.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.3'
             rails-version: '7.2'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.3'
-            rails-version: '7.2'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.3'
             rails-version: '8.0'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.3'
-            rails-version: '8.0'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.3'
             rails-version: '8.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.3'
-            rails-version: '8.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
 
           # Ruby 3.4 - Rails 7.0-8.1
           - ruby-version: '3.4'
             rails-version: '7.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.4'
-            rails-version: '7.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.4'
             rails-version: '7.2'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.4'
-            rails-version: '7.2'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.4'
             rails-version: '8.0'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.4'
-            rails-version: '8.0'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '3.4'
             rails-version: '8.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '3.4'
-            rails-version: '8.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
 
           # Ruby 4.0 - Rails 7.2-8.1
           - ruby-version: '4.0'
             rails-version: '7.2'
-            rabl-gem: 'rabl'
-          - ruby-version: '4.0'
-            rails-version: '7.2'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '4.0'
             rails-version: '8.0'
-            rabl-gem: 'rabl'
-          - ruby-version: '4.0'
-            rails-version: '8.0'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
           - ruby-version: '4.0'
             rails-version: '8.1'
-            rabl-gem: 'rabl'
-          - ruby-version: '4.0'
-            rails-version: '8.1'
-            rabl-gem: 'rabl-rails'
-            continue-on-error: true
 
           # Special Ruby versions
           - ruby-version: 'head'
             rails-version: '8.1'
-            rabl-gem: 'rabl'
-            continue-on-error: true
-          - ruby-version: 'head'
-            rails-version: '8.1'
-            rabl-gem: 'rabl-rails'
             continue-on-error: true
           - ruby-version: 'truffleruby'
             rails-version: '8.1'
-            rabl-gem: 'rabl'
-            continue-on-error: true
-          - ruby-version: 'truffleruby'
-            rails-version: '8.1'
-            rabl-gem: 'rabl-rails'
             continue-on-error: true
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         persist-credentials: false
-
-    - name: Set RABL_GEM environment variable
-      run: echo "RABL_GEM=${{ matrix.rabl-gem }}" >> $GITHUB_ENV
 
     - name: Set RAILS_VERSION environment variable
       run: echo "RAILS_VERSION=${{ matrix.rails-version }}" >> $GITHUB_ENV

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in gon.gemspec
-gem ENV['RABL_GEM'] || 'rabl'
+gem 'rabl'
 gem 'concurrent-ruby', '< 1.3.5' if ENV['RAILS_VERSION'] && ENV['RAILS_VERSION'].to_f < 7.1
 gem 'i18n', '< 1.15' if RUBY_VERSION < '3.2'
 gem 'loofah', '2.20.0' if RUBY_VERSION < '2.5'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you need to send some data to your js files and you don't want to do this wit
 
 Now you can easily renew data in your variables through ajax with [gon.watch](https://github.com/gazay/gon/wiki/Usage-gon-watch)!
 
-With [Jbuilder](https://github.com/rails/jbuilder), [Rabl](https://github.com/nesquena/rabl), and [Rabl-Rails](https://github.com/ccocchi/rabl-rails) support!
+With [Jbuilder](https://github.com/rails/jbuilder) and [Rabl](https://github.com/nesquena/rabl) support!
 
 For Sinatra available [gon-sinatra](https://github.com/gazay/gon-sinatra).
 
@@ -178,30 +178,6 @@ Profit of using Rabl with gon:
 
 [Instruction](https://github.com/gazay/gon/wiki/Usage-with-rabl) for
 usage gon with Rabl.
-
-## Usage with Rabl-Rails
-`gon.rabl` works with [rabl-rails](https://github.com/ccocchi/rabl-rails). Learn to write RABL the rabl-rails way [here](https://github.com/ccocchi/rabl-rails).
-
-Add gon and rabl-rails to your environment:
-```ruby
-gem 'gon'
-gem 'rabl-rails'
-```
-Define a rabl template using rabl-rails syntax:
-```rabl
-#app/views/users/show.rabl
-object :@user
-attributes :id, :name, :email, :location
-```
-Call gon.rabl in your controller
-
-```ruby
-#app/controllers/users_controller.rb
-def show
-  @user = User.find(params[:id])
-  gon.rabl
-end
-```
 
 ## Usage with Jbuilder
 

--- a/lib/gon/rabl.rb
+++ b/lib/gon/rabl.rb
@@ -6,10 +6,6 @@ begin
   require 'rabl' # use rabl gem if it's available
 rescue LoadError
 end
-begin
-  require 'rabl-rails' # use rabl-rails gem if it's available
-rescue LoadError
-end
 
 class Gon
   module Rabl
@@ -32,33 +28,13 @@ class Gon
       private
 
       def parse_rabl(rabl_path, controller, locals)
-        if defined? ::Rabl
-          parse_with_rabl rabl_path, controller, locals
-        elsif defined? ::RablRails
-          parse_with_rabl_rails rabl_path, controller, locals
-        else
-          raise 'rabl or rabl-rails must be required in order to use gon.rabl'
-        end
-      end
+        raise 'rabl must be required in order to use gon.rabl' unless defined? ::Rabl
 
-      def parse_with_rabl(rabl_path, controller, locals)
         locals ||= {}
         source = File.read(rabl_path)
         include_helpers
         rabl_engine = ::Rabl::Engine.new(source, :format => 'json', :template => rabl_path)
         output = rabl_engine.render(controller, locals)
-        JSON.parse(output)
-      end
-
-      def parse_with_rabl_rails(rabl_path, controller, locals)
-        locals ||= {}
-        source = File.read(rabl_path)
-        original_formats = controller.formats
-        controller.formats = [:json]
-        view_context = controller.send(:view_context)
-        locals.each { |k, v| view_context.assigns[k.to_s] = v }
-        output = RablRails::Library.instance.get_rendered_template(source, view_context)
-        controller.formats = original_formats
         JSON.parse(output)
       end
 

--- a/spec/gon/rabl_spec.rb
+++ b/spec/gon/rabl_spec.rb
@@ -47,12 +47,11 @@ describe Gon do
       expect(Gon.objects.first['object']['time_ago']).to eq('about 6 hours')
     end
 
-    it 'raise exception if rabl is not included' do
-      Gon.send :remove_const, 'Rabl'
-      expect { Gon.rabl :template => 'spec/test_data/sample.rabl', :controller => controller }.to raise_error(NameError)
-      rabl_gem = ENV.fetch('RABL_GEM', 'rabl')
-      load "#{rabl_gem}.rb"
-      load 'gon/rabl.rb'
+    it 'raises an exception if rabl is not included' do
+      hide_const('Rabl')
+
+      expect { Gon.rabl :template => 'spec/test_data/sample.rabl', :controller => controller }
+        .to raise_error(RuntimeError, 'rabl must be required in order to use gon.rabl')
     end
 
     context '.template_path' do


### PR DESCRIPTION
rabl-rails integration has a production-blocking issue reported in #317.

Despite the integration having existed for years, no related reports were received before this investigation, suggesting that it has little or no real-world usage.

Maintaining the integration would require fixing and continuously testing a separate rendering path. Given the lack of demonstrated usage, remove it instead of expanding its maintenance burden.

Remove the rabl-rails renderer, documentation, dependency switching, and CI matrix entries. gon.rabl continues to support the rabl gem.

This is a breaking change for applications using gon with rabl-rails.

Related: #294
